### PR TITLE
FE 요청사항 수정

### DIFF
--- a/src/main/java/com/kr/matitting/constant/PartyDecision.java
+++ b/src/main/java/com/kr/matitting/constant/PartyDecision.java
@@ -1,0 +1,11 @@
+package com.kr.matitting.constant;
+
+public enum PartyDecision {
+    ACCEPT("ACCEPT"), REFUSE("REFUSE");
+
+    PartyDecision(String key) {
+        this.key = key;
+    }
+
+    private final String key;
+}

--- a/src/main/java/com/kr/matitting/constant/PartyJoinStatus.java
+++ b/src/main/java/com/kr/matitting/constant/PartyJoinStatus.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum PartyJoinStatus {
     //파티 참가 수락/대기/거절
-    ACCEPT("ACCEPT"), WAIT("WAIT"), REFUSE("REFUSE");
+    APPLY("APPLY"), CANCEL("CANCEL");
 
     PartyJoinStatus(String key) {
         this.key = key;

--- a/src/main/java/com/kr/matitting/controller/PartyController.java
+++ b/src/main/java/com/kr/matitting/controller/PartyController.java
@@ -1,12 +1,9 @@
 package com.kr.matitting.controller;
 
 import com.kr.matitting.constant.Role;
+import com.kr.matitting.dto.*;
 import com.kr.matitting.entity.Party;
 import com.kr.matitting.entity.User;
-import com.kr.matitting.dto.PartyCreateDto;
-import com.kr.matitting.dto.PartyJoinDto;
-import com.kr.matitting.dto.PartyUpdateDto;
-import com.kr.matitting.dto.ResponsePartyDto;
 import com.kr.matitting.exception.Map.MapExceptionType;
 import com.kr.matitting.exception.party.PartyExceptionType;
 import com.kr.matitting.exception.partyjoin.PartyJoinExceptionType;
@@ -76,8 +73,8 @@ public class PartyController {
             @ApiResponse(responseCode = "800", description = "파티 정보가 없습니다.", content = @Content(schema = @Schema(implementation = PartyExceptionType.class)))
     })
     @GetMapping("/{partyId}")
-    public ResponseEntity<ResponsePartyDto> partyDetail(@PathVariable Long partyId) {
-        ResponsePartyDto partyInfo = partyService.getPartyInfo(partyId);
+    public ResponseEntity<ResponsePartyDetailDto> partyDetail(@AuthenticationPrincipal User user, @PathVariable Long partyId) {
+        ResponsePartyDetailDto partyInfo = partyService.getPartyInfo(user, partyId);
         return ResponseEntity.ok().body(partyInfo);
     }
 
@@ -112,8 +109,8 @@ public class PartyController {
             @ApiResponse(responseCode = "800", description = "파티 정보가 없습니다.", content = @Content(schema = @Schema(implementation = PartyExceptionType.class)))
     })
     @PostMapping("/decision")
-    public ResponseEntity<String> AcceptRefuseParty(@RequestBody @Valid PartyJoinDto partyJoinDto, @AuthenticationPrincipal User user) {
-        String result = partyService.decideUser(partyJoinDto, user);
+    public ResponseEntity<String> AcceptRefuseParty(@RequestBody @Valid PartyDecisionDto partyDecisionDto, @AuthenticationPrincipal User user) {
+        String result = partyService.decideUser(partyDecisionDto, user);
         return ResponseEntity.ok().body(result);
     }
 
@@ -122,9 +119,9 @@ public class PartyController {
             @ApiResponse(responseCode = "200", description = "파티 현황 불러오기 성공", content = @Content(schema = @Schema(implementation = ResponsePartyDto.class))),
             @ApiResponse(responseCode = "1000", description = "파티 팀 정보가 없습니다.", content = @Content(schema = @Schema(implementation = TeamExceptionType.class)))
     })
-    @GetMapping("/{userId}/party-status")
-    public ResponseEntity<List<ResponsePartyDto>> myPartyList(@PathVariable Long userId, @RequestParam Role role) {
-        List<ResponsePartyDto> myPartyList = userService.getMyPartyList(userId, role);
+    @GetMapping("/party-status")
+    public ResponseEntity<List<ResponsePartyDto>> myPartyList(@AuthenticationPrincipal User user,@NotNull @RequestParam Role role) {
+        List<ResponsePartyDto> myPartyList = userService.getMyPartyList(user, role);
         return ResponseEntity.ok().body(myPartyList);
     }
 
@@ -132,9 +129,11 @@ public class PartyController {
     //TODO: 파티 신청 리스트
     // 내가 보낸것들, 내가 받은 것들 구분!
     @GetMapping("/join")
-    public ResponseEntity<?> getJoinList(@AuthenticationPrincipal User user,
+    public ResponseEntity<List<InvitationRequestDto>> getJoinList(@AuthenticationPrincipal User user,
                                          @NotNull @RequestParam Role role) {
-        List<Party> joinList = partyService.getJoinList(user, role);
-        return ResponseEntity.ok(joinList);
+        List<InvitationRequestDto> invitationRequestDtos = partyService.getJoinList(user, role);
+        return ResponseEntity.ok(invitationRequestDtos);
     }
+
+
 }

--- a/src/main/java/com/kr/matitting/dto/InvitationRequestDto.java
+++ b/src/main/java/com/kr/matitting/dto/InvitationRequestDto.java
@@ -1,0 +1,62 @@
+package com.kr.matitting.dto;
+
+import com.kr.matitting.constant.Gender;
+import com.kr.matitting.constant.PartyAge;
+import com.kr.matitting.constant.Role;
+import com.kr.matitting.entity.Party;
+import com.kr.matitting.entity.User;
+import com.kr.matitting.entity.PartyJoin;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvitationRequestDto {
+    @Schema(description = "파티 id", nullable = false, example = "1")
+    @NotNull
+    private Long partyId;
+    @Schema(description = "파티 제목", nullable = false, example = "붕어빵 드실 분")
+    @NotNull
+    private String partyTitle;
+    @Schema(description = "사용자 닉네임", nullable = false, example = "안경잡이 개발자")
+    private String nickname; //닉네임
+    @Schema(description = "사용자 프로필 이미지", nullable = true, example = "증명사진.jpg")
+    @Column(name = "user_img")
+    private String imgUrl;
+    @Schema(description = "성별", nullable = false, example = "ALL")
+    @NotNull
+    private Gender partyGender;
+    @Schema(description = "연령대", nullable = false, example = "2030")
+    @NotNull
+    private PartyAge partyAge;
+
+    @Schema(description = "사용자 성별", nullable = false, example = "MALE")
+    @NotNull
+    private Gender userGender;
+
+    @Schema(description = "사용자 나이", nullable = false, example = "26")
+    @NotNull
+    private Integer userAge;
+
+    public static InvitationRequestDto toDto(PartyJoin partyJoin, User user, Role role) {
+        Party party = partyJoin.getParty();
+
+        return InvitationRequestDto.builder()
+                .partyId(party.getId())
+                .partyTitle(party.getPartyTitle())
+                .nickname(role.equals(Role.VOLUNTEER) ? null:user.getNickname())
+                .imgUrl(user.getImgUrl())
+                .partyGender(party.getGender())
+                .partyAge(party.getAge())
+                .userGender(user.getGender())
+                .userAge(user.getAge())
+                .build();
+    }
+}

--- a/src/main/java/com/kr/matitting/dto/PartyDecisionDto.java
+++ b/src/main/java/com/kr/matitting/dto/PartyDecisionDto.java
@@ -1,0 +1,26 @@
+package com.kr.matitting.dto;
+
+import com.kr.matitting.constant.PartyDecision;
+import com.kr.matitting.constant.PartyJoinStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartyDecisionDto {
+    @Schema(description = "파티 아이디", example = "13")
+    @NotNull
+    private Long partyId;
+    @Schema(description = "참가 요청자 유저 닉네임", example = "새싹개발자")
+    private String nickname;
+    @Schema(description = "파티 신청 수락/거절", example = "ACCEPT")
+    @NotNull
+    private PartyDecision status;
+
+}

--- a/src/main/java/com/kr/matitting/dto/PartyJoinDto.java
+++ b/src/main/java/com/kr/matitting/dto/PartyJoinDto.java
@@ -13,12 +13,12 @@ public record PartyJoinDto(
         @Schema(description = "파티장 아이디", example = "1")
         @NotNull
         Long leaderId,
-        @Schema(description = "파티 신청 수락/거절", example = "ACCEPT")
+        @Schema(description = "파티 신청 수락/거절", example = "APPLY")
         @NotNull
         PartyJoinStatus status
 
 ) {
     public PartyJoinDto PartyJoinDto(Long partyId, Long leaderId, PartyJoinStatus status) {
-        return new PartyJoinDto(partyId, leaderId, (status == null) ? PartyJoinStatus.WAIT : status);
+        return new PartyJoinDto(partyId, leaderId, status);
     }
 }

--- a/src/main/java/com/kr/matitting/dto/ResponsePartyDetailDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponsePartyDetailDto.java
@@ -22,7 +22,7 @@ public class ResponsePartyDetailDto {
     private Long userId;
 
     @Schema(description = "방장 여부", example = "true or false")
-    private Boolean leaderTF;
+    private Boolean isLeader;
     @Schema(description = "파티 id", nullable = false, example = "1")
     @NotNull
     private Long partyId;

--- a/src/main/java/com/kr/matitting/dto/ResponsePartyDetailDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponsePartyDetailDto.java
@@ -1,0 +1,76 @@
+package com.kr.matitting.dto;
+
+import com.kr.matitting.constant.Gender;
+import com.kr.matitting.constant.PartyAge;
+import com.kr.matitting.constant.PartyCategory;
+import com.kr.matitting.constant.PartyStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponsePartyDetailDto {
+    @Schema(description = "유저 id", example = "10")
+    private Long userId;
+
+    @Schema(description = "방장 여부", example = "true or false")
+    private Boolean leaderTF;
+    @Schema(description = "파티 id", nullable = false, example = "1")
+    @NotNull
+    private Long partyId;
+
+    @Schema(description = "파티 제목", nullable = false, example = "붕어빵 드실 분")
+    @NotNull
+    private String partyTitle;
+    @Schema(description = "파티 내용", nullable = false, example = "붕어빵은 팥이 근본입니다.")
+    @NotNull
+    private String partyContent;
+    @Schema(description = "주소", nullable = false, example = "서울 송파구 송파동 7-1")
+    @NotNull
+    private String address;
+    @Schema(description = "경도", nullable = false, example = "126.88453591058602")
+    @NotNull
+    private double longitude;
+    @Schema(description = "위도", nullable = false, example = "37.53645109566274")
+    @NotNull
+    private double latitude;
+    @Schema(description = "파티 상태", nullable = false, example = "RECRUIT")
+    @NotNull
+    private PartyStatus status;
+    @Schema(description = "성별", nullable = false, example = "ALL")
+    @NotNull
+    private Gender gender;
+    @Schema(description = "연령대", nullable = false, example = "2030")
+    @NotNull
+    private PartyAge age;
+    @Schema(description = "파티 모집 마감 시간", nullable = false, example = "2023-10-24T09:00:00")
+    @NotNull
+    private LocalDateTime deadline;
+    @Schema(description = "파티 시작 시간", nullable = false, example = "2023-10-24T10:00:00")
+    @NotNull
+    private LocalDateTime partyTime;
+    @Schema(description = "모집 인원", nullable = false, example = "4")
+    @NotNull
+    private Integer totalParticipate;
+    @Schema(description = "현재 참가 인원", nullable = false, example = "2")
+    @NotNull
+    private Integer participate;
+    @Schema(description = "파티 메뉴", nullable = true, example = "붕어빵")
+    private String menu;
+    @Schema(description = "카테고리", nullable = false, example = "한식")
+    private PartyCategory category;
+    @Schema(description = "썸네일", nullable = true, example = " https://matitting.s3.ap-northeast-2.amazonaws.com/korean.jpeg")
+    @NotNull
+    private String thumbnail;
+    @Schema(description = "조회수", nullable = false, example = "1")
+    @NotNull
+    private Integer hit;
+}

--- a/src/main/java/com/kr/matitting/repository/PartyJoinRepository.java
+++ b/src/main/java/com/kr/matitting/repository/PartyJoinRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
     List<PartyJoin> findByLeaderId(Long leaderId);
     List<PartyJoin> findByPartyIdAndLeaderId(Long partyId, Long leaderId);
-    Optional<PartyJoin> findByPartyIdAndLeaderIdAndUserId(Long partyId, Long leaderId, Long userId);
+    Optional<PartyJoin> findByPartyIdAndUserId(Long partyId, Long userId);
     List<PartyJoin> findByPartyId(Long partyId);
 
     List<PartyJoin> findAllByLeaderId(Long userId);

--- a/src/main/java/com/kr/matitting/repository/UserRepository.java
+++ b/src/main/java/com/kr/matitting/repository/UserRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialId(String socialId);
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/kr/matitting/security/SecurityConfig.java
+++ b/src/main/java/com/kr/matitting/security/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         getCustomizer(introspector,
                                 "/", "/home", "/matitting", "/member/signupForm", "/oauth2/**", "/resources/**", "/demo-ui.html",
-                                "/swagger-ui/**", "/api-docs/**", "/api/main", "/api/search", "/api/search/**", "api/party/{userId}",
+                                "/swagger-ui/**", "/api-docs/**", "/api/main", "/api/search**", "api/party/{userId}",
                                 "/api/chat-rooms/**", "/webjars/**", "/favicon.ico")
                 )
                 .formLogin((form) -> form

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -54,7 +54,7 @@ public class PartyService {
         increaseHit(partyId);
         return ResponsePartyDetailDto.builder()
                 .userId(party.getUser().getId())
-                .leaderTF(user == null || (user.getId() != party.getUser().getId()) ? false : true)
+                .isLeader(user == null || (user.getId() != party.getUser().getId()) ? false : true)
                 .partyId(party.getId())
                 .partyTitle(party.getPartyTitle())
                 .partyContent(party.getPartyContent())

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -1,9 +1,6 @@
 package com.kr.matitting.service;
 
-import com.kr.matitting.constant.PartyCategory;
-import com.kr.matitting.constant.PartyJoinStatus;
-import com.kr.matitting.constant.PartyStatus;
-import com.kr.matitting.constant.Role;
+import com.kr.matitting.constant.*;
 import com.kr.matitting.dto.*;
 import com.kr.matitting.entity.Party;
 import com.kr.matitting.entity.PartyJoin;
@@ -33,10 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.awt.geom.Point2D;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.kr.matitting.dto.ChatRoomDto.*;
@@ -54,10 +48,31 @@ public class PartyService {
     private final PartyRepository partyRepository;
     private final UserRepository userRepository;
     private final MapService mapService;
-    public ResponsePartyDto getPartyInfo(Long partyId) {
+
+    public ResponsePartyDetailDto getPartyInfo(User user, Long partyId) {
         Party party = partyRepository.findById(partyId).orElseThrow(() -> new PartyException(PartyExceptionType.NOT_FOUND_PARTY));
         increaseHit(partyId);
-        return ResponsePartyDto.toDto(party);
+        return ResponsePartyDetailDto.builder()
+                .userId(party.getUser().getId())
+                .leaderTF(user == null || (user.getId() != party.getUser().getId()) ? false : true)
+                .partyId(party.getId())
+                .partyTitle(party.getPartyTitle())
+                .partyContent(party.getPartyContent())
+                .address(party.getAddress())
+                .longitude(party.getLongitude())
+                .latitude(party.getLatitude())
+                .status(party.getStatus())
+                .gender(party.getGender())
+                .age(party.getAge())
+                .deadline(party.getDeadline())
+                .partyTime(party.getPartyTime())
+                .totalParticipate(party.getTotalParticipant())
+                .participate(party.getParticipantCount())
+                .menu(party.getMenu())
+                .category(party.getCategory())
+                .thumbnail(party.getThumbnail())
+                .hit(party.getHit())
+                .build();
     }
 
     @Transactional
@@ -223,34 +238,45 @@ public class PartyService {
         if (!party.getUser().getId().equals(partyJoinDto.leaderId())) {
             throw new UserException(UserExceptionType.NOT_FOUND_USER);
         }
-        PartyJoin partyJoin = PartyJoin.builder().party(party).leaderId(partyJoinDto.leaderId()).userId(user.getId()).build();
-        partyJoinRepository.save(partyJoin);
+        
+        if (partyJoinDto.status() == PartyJoinStatus.APPLY) {
+            PartyJoin partyJoin = PartyJoin.builder().party(party).leaderId(partyJoinDto.leaderId()).userId(user.getId()).build();
+            partyJoinRepository.save(partyJoin);
+        } else if (partyJoinDto.status() == PartyJoinStatus.CANCEL) {
+            Optional<PartyJoin> partyJoin = partyJoinRepository.findByPartyIdAndUserId(partyJoinDto.partyId(), user.getId());
+            if (partyJoin.isPresent()) {
+                partyJoinRepository.delete(partyJoin.get());
+            }
+            //TODO: 1:1 단톡방을 삭제하는 로직 추가 예정!
+        }
+
     }
 
-    public String decideUser(PartyJoinDto partyJoinDto, User user) {
+    public String decideUser(PartyDecisionDto partyDecisionDto, User user) {
         log.info("=== decideUser() start ===");
 
-        if (!(partyJoinDto.status() == PartyJoinStatus.ACCEPT || partyJoinDto.status() == PartyJoinStatus.REFUSE)) {
+        if (!(partyDecisionDto.getStatus() == PartyDecision.ACCEPT || partyDecisionDto.getStatus() == PartyDecision.REFUSE)) {
             log.error("=== Party Join Status was requested incorrectly ===");
             throw new PartyJoinException(PartyJoinExceptionType.WRONG_STATUS);
         }
 
-        PartyJoin findPartyJoin = partyJoinRepository.findByPartyIdAndLeaderIdAndUserId(
-                partyJoinDto.partyId(),
-                partyJoinDto.leaderId(),
+        PartyJoin findPartyJoin = partyJoinRepository.findByPartyIdAndUserId(
+                partyDecisionDto.getPartyId(),
                 user.getId()).orElseThrow(() -> new PartyJoinException(PartyJoinExceptionType.NOT_FOUND_PARTY_JOIN));
         partyJoinRepository.delete(findPartyJoin);
 
-        if (partyJoinDto.status() == PartyJoinStatus.ACCEPT) {
+        if (partyDecisionDto.getStatus() == PartyDecision.ACCEPT) {
             log.info("=== ACCEPT ===");
-            Party party = partyRepository.findById(partyJoinDto.partyId()).orElseThrow(() -> new PartyException(PartyExceptionType.NOT_FOUND_PARTY));
+            User volunteerUser = userRepository.findByNickname(partyDecisionDto.getNickname()).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
+
+            Party party = partyRepository.findById(partyDecisionDto.getPartyId()).orElseThrow(() -> new PartyException(PartyExceptionType.NOT_FOUND_PARTY));
             party.increaseUser();
             if (party.getTotalParticipant() == party.getParticipantCount()) {
                 party.setStatus(PartyStatus.FINISH);
             }
-
-            Team member = Team.builder().user(user).party(party).role(Role.VOLUNTEER).build();
+            Team member = Team.builder().user(volunteerUser).party(party).role(Role.VOLUNTEER).build();
             teamRepository.save(member);
+
             return "Accept Request Completed";
         } else {
             log.info("=== REFUSE ===");
@@ -258,15 +284,25 @@ public class PartyService {
         }
     }
 
-    public List<Party> getJoinList(User user, Role role) {
+    public List<InvitationRequestDto> getJoinList(User user, Role role) {
         List<PartyJoin> partyJoinList;
+        List<InvitationRequestDto> invitationRequestDtos;
         if (role.equals(Role.HOST)) {
             partyJoinList = partyJoinRepository.findAllByLeaderId(user.getId());
+            invitationRequestDtos = partyJoinList.stream().map(partyJoin -> {
+                User volunteerUser = userRepository.findById(partyJoin.getUserId()).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
+                return InvitationRequestDto.toDto(partyJoin, volunteerUser, role);
+            }).toList();
         } else if (role.equals(Role.VOLUNTEER)) {
             partyJoinList = partyJoinRepository.findAllByUserId(user.getId());
+            invitationRequestDtos = partyJoinList.stream().map(partyJoin -> {
+                User leaderUser = userRepository.findById(partyJoin.getLeaderId()).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
+                return InvitationRequestDto.toDto(partyJoin, leaderUser, role);
+            }).toList();
         } else {
             throw new UserException(UserExceptionType.INVALID_ROLE_USER);
         }
-        return partyJoinList.stream().map(PartyJoin::getParty).toList();
+
+        return invitationRequestDtos;
     }
 }

--- a/src/main/java/com/kr/matitting/service/UserService.java
+++ b/src/main/java/com/kr/matitting/service/UserService.java
@@ -84,23 +84,17 @@ public class UserService {
         return user;
     }
 
-    public List<ResponsePartyDto> getMyPartyList(Long userId, Role role) {
+    public List<ResponsePartyDto> getMyPartyList(User user, Role role) {
         List<ResponsePartyDto> parties;
         List<Team> teams;
 
-        if (userId == null) {
-            throw new NullPointerException("UserId is Null");
-        } else if (role == null) {
-            throw new NullPointerException("Role is Null");
-        }
-
         if (role == Role.HOST || role == Role.VOLUNTEER) {
-            teams = partyTeamRepository.findByUserIdAndRole(userId, role);
+            teams = partyTeamRepository.findByUserIdAndRole(user.getId(), role);
             parties = teams.stream().map(team -> team.getParty()).filter(party -> party.getStatus() != PartyStatus.FINISH).map(party -> ResponsePartyDto.toDto(party)).sorted(Comparator.comparing(ResponsePartyDto::partyTime)).toList();
             return parties;
         }
         else if(role == Role.USER){
-            teams = partyTeamRepository.findByUserId(userId);
+            teams = partyTeamRepository.findByUserId(user.getId() );
             parties = teams.stream().map(team -> team.getParty()).filter(party -> party.getStatus() == PartyStatus.FINISH).map(party -> ResponsePartyDto.toDto(party)).sorted(Comparator.comparing(ResponsePartyDto::partyTime)).toList();
             return parties;
             }


### PR DESCRIPTION
### 구현 목록
1. 프로필 URI 변경
2. 초대 요청 기능
- Request 파라미터로 Role(HOST or VOLUNTEER)을 요청 후 방장 or 지원자 list를 긁어서 아래와 같은 정보를 return
- 파티Id, 파티제목, 사용자 이미지, 파티성별, 파티연령, 사용자 성별, 사용자 연령
3. decisipon -> leaderId 삭제
4. decision에서 방장이 신청을 수락하는 신청자 식별을 nickname으로 진행!(로직변경함)
5. partyDetail 페이지를 볼 때 사용자가 방장인지 아닌지 Boolean Column 반환
6. participation 로직 APPLY or CANCEL로 지원자가 지원 or 지원취소 가능