### PR TITLE
[fix] entity 수정에 따른 코드 수정, Security 접근제한 경로 수정

### DIFF
--- a/src/main/java/com/kr/matitting/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kr/matitting/jwt/filter/JwtAuthenticationFilter.java
@@ -40,7 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Value("${jwt.secret}")
     private String secretKey;
 
-    private static final String[] whitelist = {"/", "/index.html", "/home", "/matitting", "/login", "/oauth2/**", "/api/main**", "/api/search**",
+    private static final String[] whitelist = {"/", "/index.html", "/home", "/matitting", "/login", "/oauth2/**", "/api/main**", "/api/search**", "/api/search/rank",
             "/login/oauth2/code/**", "/oauth2/signUp", "/error", "/js/**","/demo-ui.html", "/swagger-ui/**", "/api-docs/**",
             "/api/chat-rooms/**", "/chat/**", "/room/**", "/webjars/**", "/favicon.ico", "/ws-stomp/**"};
 

--- a/src/main/java/com/kr/matitting/security/SecurityConfig.java
+++ b/src/main/java/com/kr/matitting/security/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         getCustomizer(introspector,
                                 "/", "/home", "/matitting", "/member/signupForm", "/oauth2/**", "/resources/**", "/demo-ui.html",
-                                "/swagger-ui/**", "/api-docs/**", "/api/main", "/api/search**", "api/party/{userId}",
+                                "/swagger-ui/**", "/api-docs/**", "/api/main", "/api/search**", "/api/search/rank", "api/party/{userId}",
                                 "/api/chat-rooms/**", "/webjars/**", "/favicon.ico")
                 )
                 .formLogin((form) -> form

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -272,7 +272,7 @@ public class PartyService {
             Party party = partyRepository.findById(partyDecisionDto.getPartyId()).orElseThrow(() -> new PartyException(PartyExceptionType.NOT_FOUND_PARTY));
             party.increaseUser();
             if (party.getTotalParticipant() == party.getParticipantCount()) {
-                party.setStatus(PartyStatus.FINISH);
+                party.setStatus(PartyStatus.RECRUIT_FINISH);
             }
             Team member = Team.builder().user(volunteerUser).party(party).role(Role.VOLUNTEER).build();
             teamRepository.save(member);

--- a/src/main/java/com/kr/matitting/service/UserService.java
+++ b/src/main/java/com/kr/matitting/service/UserService.java
@@ -90,12 +90,12 @@ public class UserService {
 
         if (role == Role.HOST || role == Role.VOLUNTEER) {
             teams = partyTeamRepository.findByUserIdAndRole(user.getId(), role);
-            parties = teams.stream().map(team -> team.getParty()).filter(party -> party.getStatus() != PartyStatus.FINISH).map(party -> ResponsePartyDto.toDto(party)).sorted(Comparator.comparing(ResponsePartyDto::partyTime)).toList();
+            parties = teams.stream().map(team -> team.getParty()).filter(party -> party.getStatus() != PartyStatus.PARTY_FINISH).map(party -> ResponsePartyDto.toDto(party)).sorted(Comparator.comparing(ResponsePartyDto::partyTime)).toList();
             return parties;
         }
         else if(role == Role.USER){
             teams = partyTeamRepository.findByUserId(user.getId() );
-            parties = teams.stream().map(team -> team.getParty()).filter(party -> party.getStatus() == PartyStatus.FINISH).map(party -> ResponsePartyDto.toDto(party)).sorted(Comparator.comparing(ResponsePartyDto::partyTime)).toList();
+            parties = teams.stream().map(team -> team.getParty()).filter(party -> party.getStatus() == PartyStatus.PARTY_FINISH).map(party -> ResponsePartyDto.toDto(party)).sorted(Comparator.comparing(ResponsePartyDto::partyTime)).toList();
             return parties;
             }
         return new LinkedList<ResponsePartyDto>();


### PR DESCRIPTION
### 구현 목록
- Security에 경로 추가
- entity value 수정

### 이슈
- JwtAuthenticationFilter와는 다르게 Security는 pattern matching 하는 방식이 달라서 그런지 /api/search** 가 먹히지 않아서 /api/search/rank 경로를 주입하여 문제 해결