### PR TITLE
[fix] Entity간 매핑 오류로 인한 파티 삭제 불가 수정

### DIFF
--- a/src/main/java/com/kr/matitting/entity/ChatRoom.java
+++ b/src/main/java/com/kr/matitting/entity/ChatRoom.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -32,6 +34,9 @@ public class ChatRoom extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private ChatRoomType roomType;
+
+    @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatUser> chatUserList = new ArrayList<>();
 
     public static ChatRoom createRoom(Party party, User user, ChatRoomType roomType, String title) {
         ChatRoom chatRoom = new ChatRoom();

--- a/src/main/java/com/kr/matitting/entity/Party.java
+++ b/src/main/java/com/kr/matitting/entity/Party.java
@@ -89,6 +89,9 @@ public class Party extends BaseTimeEntity {
     @OneToMany(mappedBy = "party", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PartyJoin> partyJoinList = new ArrayList<>();
 
+    @OneToOne(mappedBy = "party", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private ChatRoom chatRoom;
+
     public void increaseUser() {
         this.participantCount++;
     }


### PR DESCRIPTION
### 이슈 사항
- Party를 삭제할 때, ChatRoom과 양방향 매핑이 안되어 있어 Cascade 부분에서 error 발생
- ChatRoom을 삭제할 때 양방향 매핑이 안되어 있어 Cascade 부분에서 error 발생