### PR TITLE
[임시] 알림 기능

### DIFF
--- a/src/main/java/com/kr/matitting/annotaiton/Notify.java
+++ b/src/main/java/com/kr/matitting/annotaiton/Notify.java
@@ -1,0 +1,11 @@
+//package com.kr.matitting.annotaiton;
+//
+//import java.lang.annotation.ElementType;
+//import java.lang.annotation.Retention;
+//import java.lang.annotation.RetentionPolicy;
+//import java.lang.annotation.Target;
+//
+//@Retention(RetentionPolicy.RUNTIME)
+//@Target({ElementType.METHOD})
+//public @interface Notify {
+//}

--- a/src/main/java/com/kr/matitting/aop/NotifyAspect.java
+++ b/src/main/java/com/kr/matitting/aop/NotifyAspect.java
@@ -1,0 +1,36 @@
+package com.kr.matitting.aop;
+
+import com.kr.matitting.entity.Notification;
+import com.kr.matitting.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Slf4j
+@Aspect
+@EnableWebMvc
+@Component
+@EnableAsync
+@RequiredArgsConstructor
+public class NotifyAspect {
+    private final NotificationService notificationService;
+
+    @Pointcut("@annotation(com.kr.matitting.annotation.Notify)")
+    public void annotationPointcut() {
+    }
+
+    @Async
+    @AfterReturning(pointcut = "annotationPointcut()", returning = "result")
+    public void checkValue(JoinPoint joinPoint, ResponseEntity<?> responseEntity) throws Throwable {
+        Object body = responseEntity.getBody();
+
+    }
+}

--- a/src/main/java/com/kr/matitting/constant/NotificationType.java
+++ b/src/main/java/com/kr/matitting/constant/NotificationType.java
@@ -1,5 +1,5 @@
 package com.kr.matitting.constant;
 
 public enum NotificationType {
-        PARTICIPATION_REQUEST, REQUEST_DECISION
+        PARTICIPATION_REQUEST, REQUEST_DECISION, REVIEW
 }

--- a/src/main/java/com/kr/matitting/constant/PartyAge.java
+++ b/src/main/java/com/kr/matitting/constant/PartyAge.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
+
 public enum PartyAge {
     TWENTY("TWENTY"), THIRTY("THIRTY"), FORTY("THIRTY"), ALL("ALL");
 

--- a/src/main/java/com/kr/matitting/constant/Role.java
+++ b/src/main/java/com/kr/matitting/constant/Role.java
@@ -1,7 +1,6 @@
 package com.kr.matitting.constant;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 public enum Role {

--- a/src/main/java/com/kr/matitting/controller/ChatController.java
+++ b/src/main/java/com/kr/matitting/controller/ChatController.java
@@ -2,7 +2,6 @@ package com.kr.matitting.controller;
 
 import com.kr.matitting.dto.ChatEvictDto;
 import com.kr.matitting.dto.ChatMessage;
-import com.kr.matitting.entity.ChatRoom;
 import com.kr.matitting.entity.User;
 import com.kr.matitting.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,10 +13,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 import static com.kr.matitting.dto.ChatRoomDto.ChatResponse;
-import static com.kr.matitting.dto.ChatRoomDto.ChatRoomItem;
 
 @RestController
 @RequestMapping("/api/chat")

--- a/src/main/java/com/kr/matitting/controller/ChatRoomController.java
+++ b/src/main/java/com/kr/matitting/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.kr.matitting.controller;
 
-import com.kr.matitting.dto.*;
+import com.kr.matitting.dto.ResponseChatRoomListDto;
+import com.kr.matitting.dto.ResponseChatRoomUserDto;
 import com.kr.matitting.entity.User;
 import com.kr.matitting.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/kr/matitting/controller/MainController.java
+++ b/src/main/java/com/kr/matitting/controller/MainController.java
@@ -1,7 +1,5 @@
 package com.kr.matitting.controller;
 
-import com.kr.matitting.constant.PartyStatus;
-import com.kr.matitting.constant.Sorts;
 import com.kr.matitting.dto.MainPageDto;
 import com.kr.matitting.dto.ResponseMainPageDto;
 import com.kr.matitting.service.MainService;
@@ -15,7 +13,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/kr/matitting/controller/NotificationController.java
+++ b/src/main/java/com/kr/matitting/controller/NotificationController.java
@@ -5,6 +5,7 @@ import com.kr.matitting.service.NotificationService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -13,19 +14,19 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
-@RequestMapping("api/notifications")
+@RequestMapping("/api/notifications")
 @RequiredArgsConstructor
 public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(
+    public ResponseEntity<SseEmitter> subscribe(
             @AuthenticationPrincipal User user,
             @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId,
             HttpServletResponse response
     ) {
         response.setHeader("X-Accel-Buffering", "no");
-        return notificationService.subscribe(user, lastEventId);
+        return ResponseEntity.ok(notificationService.subscribe(user, lastEventId));
     }
 }
 

--- a/src/main/java/com/kr/matitting/controller/PartyController.java
+++ b/src/main/java/com/kr/matitting/controller/PartyController.java
@@ -2,6 +2,7 @@ package com.kr.matitting.controller;
 
 import com.kr.matitting.constant.Role;
 import com.kr.matitting.dto.*;
+import com.kr.matitting.entity.Notification;
 import com.kr.matitting.entity.User;
 import com.kr.matitting.exception.Map.MapExceptionType;
 import com.kr.matitting.exception.party.PartyExceptionType;
@@ -78,6 +79,11 @@ public class PartyController {
     @PatchMapping("{partyId}")
     public ResponseEntity<String> updateParty(@RequestBody PartyUpdateDto partyUpdateDto, @PathVariable Long partyId) {
         partyService.partyUpdate(partyUpdateDto, partyId);
+
+        Notification.builder()
+
+                .build();
+
         return ResponseEntity.ok().body("Success Party update");
     }
 

--- a/src/main/java/com/kr/matitting/controller/ReviewController.java
+++ b/src/main/java/com/kr/matitting/controller/ReviewController.java
@@ -1,0 +1,28 @@
+package com.kr.matitting.controller;
+
+import com.kr.matitting.dto.ReviewDto;
+import com.kr.matitting.entity.User;
+import com.kr.matitting.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/review")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping
+    public ResponseEntity<?> setReview(@AuthenticationPrincipal User user, @RequestBody ReviewDto reviewDto) {
+        reviewService.setReview(user, reviewDto);
+        return ResponseEntity.ok(null);
+    }
+
+
+}

--- a/src/main/java/com/kr/matitting/controller/SearchController.java
+++ b/src/main/java/com/kr/matitting/controller/SearchController.java
@@ -1,13 +1,14 @@
 package com.kr.matitting.controller;
 
-import com.kr.matitting.dto.*;
+import com.kr.matitting.dto.PartySearchCondDto;
+import com.kr.matitting.dto.ResponseRankingDto;
+import com.kr.matitting.dto.ResponseSearchPageDto;
 import com.kr.matitting.service.SearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/kr/matitting/controller/TestController.java
+++ b/src/main/java/com/kr/matitting/controller/TestController.java
@@ -1,0 +1,96 @@
+package com.kr.matitting.controller;
+
+import com.kr.matitting.constant.*;
+import com.kr.matitting.entity.Party;
+import com.kr.matitting.entity.User;
+import com.kr.matitting.jwt.service.JwtService;
+import com.kr.matitting.repository.PartyRepository;
+import com.kr.matitting.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RestController
+public class TestController {
+    private final UserRepository userRepository;
+    private final PartyRepository partyRepository;
+    private final JwtService jwtService;
+
+    @PostMapping("/matitting777")
+    public Map<String, String> dummy() {
+        User user = User.builder()
+                .socialId("12309812309128301")
+                .oauthProvider(OauthProvider.KAKAO)
+                .email("test@kakao.com")
+                .nickname("새싹개발자")
+                .age(20)
+                .imgUrl("증명사진100.jpg")
+                .gender(Gender.FEMALE)
+                .role(Role.USER)
+                .build();
+        User savedUser = userRepository.save(user);
+        String accessToken = jwtService.createAccessToken(savedUser);
+
+        Party party = Party.builder()
+                .partyTitle("새싹개발자와 돈까스를 먹자!")
+                .partyContent("치즈 돈까스 vs 생선 돈까스!")
+                .address("서울특별시 마포구 포은로2나길 44")
+                .partyPlaceName("크레이지 카츠")
+                .longitude(126.90970359894729)
+                .latitude(37.55045202364851)
+                .status(PartyStatus.RECRUIT)
+                .deadline(LocalDateTime.now().plusDays(3))
+                .partyTime(LocalDateTime.now().plusDays(3).plusHours(1))
+                .totalParticipant(4)
+                .participantCount(1)
+                .gender(Gender.ALL)
+                .age(PartyAge.ALL)
+                .hit(0)
+                .thumbnail("https://matitting.s3.ap-northeast-2.amazonaws.com/japanese.jpeg")
+                .menu("돈까스")
+                .category(PartyCategory.JAPANESE)
+                .user(user)
+                .build();
+        Party savedParty = partyRepository.save(party);
+
+        User user2 = User.builder()
+                .socialId("213312213")
+                .oauthProvider(OauthProvider.NAVER)
+                .email("parksn5029@naver.com")
+                .nickname("잔디개발자")
+                .age(22)
+                .imgUrl("망한사진.jpg")
+                .gender(Gender.FEMALE)
+                .role(Role.USER)
+                .build();
+        User saved2 = userRepository.save(user2);
+        String saved2AccessToken = jwtService.createAccessToken(saved2);
+
+        User user3 = User.builder()
+                .socialId("16742355")
+                .oauthProvider(OauthProvider.NAVER)
+                .email("test@test.com")
+                .nickname("잔잔바리")
+                .age(22)
+                .imgUrl("원숭이.jpg")
+                .gender(Gender.MALE)
+                .role(Role.USER)
+                .build();
+        User saved3 = userRepository.save(user3);
+        String saved3AccessToken = jwtService.createAccessToken(saved3);
+
+        Map<String, String> data = new HashMap<>();
+        data.put("지원자 Id", String.valueOf(saved2.getId()));
+        data.put("파티 ID", String.valueOf(savedParty.getId()));
+        data.put("지원자 token", saved2AccessToken);
+        data.put("지원자2 token", saved3AccessToken);
+        data.put("방장 token", accessToken);
+
+        return data;
+    }
+}

--- a/src/main/java/com/kr/matitting/dto/NotificationDto.java
+++ b/src/main/java/com/kr/matitting/dto/NotificationDto.java
@@ -4,6 +4,8 @@ import com.kr.matitting.constant.NotificationType;
 import com.kr.matitting.entity.Notification;
 import lombok.*;
 
+import java.time.LocalDate;
+
 public class NotificationDto {
     @AllArgsConstructor
     @Builder
@@ -13,6 +15,7 @@ public class NotificationDto {
     public static class Response {
         String id;
         String name;
+        String title;
         String content;
         NotificationType type;
         String createdAt;
@@ -20,11 +23,12 @@ public class NotificationDto {
         String lastEventId;
         public static Response createResponse(Notification notification, String lastEventId) {
             return Response.builder()
+                    .title(notification.getTitle())
                     .content(notification.getContent())
                     .id(notification.getId().toString())
                     .name(notification.getReceiver().getNickname())
                     .type(notification.getNotificationType())
-                    .createdAt(notification.getCreateDate().toString())
+                    .createdAt(LocalDate.from(notification.getCreateDate()).toString())
                     .lastEventId(lastEventId)
                     .build();
         }

--- a/src/main/java/com/kr/matitting/dto/ReviewDto.java
+++ b/src/main/java/com/kr/matitting/dto/ReviewDto.java
@@ -1,0 +1,13 @@
+package com.kr.matitting.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDto {
+    private Long userId;
+    private String content;
+}

--- a/src/main/java/com/kr/matitting/entity/Notification.java
+++ b/src/main/java/com/kr/matitting/entity/Notification.java
@@ -15,17 +15,20 @@ public class Notification extends BaseTimeEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id")
     private Long id;
+    private String title;
     private String content;
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private NotificationType notificationType;
-    @ManyToOne
-    @JoinColumn(name = "member_id")
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User receiver;
     @Builder
-    public Notification(User receiver, NotificationType notificationType, String content) {
+    public Notification(User receiver, NotificationType notificationType, String title, String content) {
         this.receiver = receiver;
         this.notificationType = notificationType;
+        this.title = title;
         this.content = content;
     }
 }

--- a/src/main/java/com/kr/matitting/entity/Party.java
+++ b/src/main/java/com/kr/matitting/entity/Party.java
@@ -1,5 +1,8 @@
 package com.kr.matitting.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.kr.matitting.constant.Gender;
 import com.kr.matitting.constant.PartyAge;
 import com.kr.matitting.constant.PartyCategory;
@@ -81,16 +84,20 @@ public class Party extends BaseTimeEntity {
     @Column(name = "category")
     private PartyCategory category;
 
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "user_id")
     private User user;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "party", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Team> teamList = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "party", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PartyJoin> partyJoinList = new ArrayList<>();
 
+    @JsonIgnore
     @OneToOne(mappedBy = "party", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private ChatRoom chatRoom;
 

--- a/src/main/java/com/kr/matitting/entity/PartyJoin.java
+++ b/src/main/java/com/kr/matitting/entity/PartyJoin.java
@@ -1,5 +1,7 @@
 package com.kr.matitting.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +18,8 @@ public class PartyJoin extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "join_id")
     private Long id;
+
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "party_id")
     private Party party;

--- a/src/main/java/com/kr/matitting/entity/Review.java
+++ b/src/main/java/com/kr/matitting/entity/Review.java
@@ -1,0 +1,27 @@
+package com.kr.matitting.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "review")
+public class Review {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+    @NotNull
+    private User host;
+    @NotNull
+    private User volunteer;
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/com/kr/matitting/entity/User.java
+++ b/src/main/java/com/kr/matitting/entity/User.java
@@ -1,5 +1,6 @@
 package com.kr.matitting.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.kr.matitting.constant.Gender;
 import com.kr.matitting.constant.Role;
 import com.kr.matitting.constant.OauthProvider;
@@ -59,6 +60,7 @@ public class User extends BaseTimeEntity{
     @Column(nullable = false)
     private Role role; //신규유저 or 기존유저
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Party> partyList = new ArrayList<>();
 

--- a/src/main/java/com/kr/matitting/repository/EmitterRepository.java
+++ b/src/main/java/com/kr/matitting/repository/EmitterRepository.java
@@ -1,16 +1,9 @@
 package com.kr.matitting.repository;
 
-import com.kr.matitting.entity.Party;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
-@Repository
 public interface EmitterRepository {
     SseEmitter save(String emitterId, SseEmitter sseEmitter);
 

--- a/src/main/java/com/kr/matitting/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/kr/matitting/repository/EmitterRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.kr.matitting.repository;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -17,14 +16,6 @@ public class EmitterRepositoryImpl implements EmitterRepository {
     public SseEmitter save(String emitterId, SseEmitter sseEmitter) { // emitter를 저장
         emitters.put(emitterId, sseEmitter);
         return sseEmitter;
-    }
-
-    public Map<String, SseEmitter> getEmitters(){
-        return emitters;
-    }
-
-    public Map<String, Object> getEventCache(){
-        return eventCache;
     }
 
     @Override

--- a/src/main/java/com/kr/matitting/repository/ReviewRepository.java
+++ b/src/main/java/com/kr/matitting/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.kr.matitting.repository;
+
+import com.kr.matitting.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/kr/matitting/scheduler/PartyScheduler.java
+++ b/src/main/java/com/kr/matitting/scheduler/PartyScheduler.java
@@ -1,8 +1,12 @@
 package com.kr.matitting.scheduler;
 
+import com.kr.matitting.constant.NotificationType;
 import com.kr.matitting.constant.PartyStatus;
+import com.kr.matitting.constant.Role;
 import com.kr.matitting.entity.Party;
+import com.kr.matitting.entity.Team;
 import com.kr.matitting.repository.PartyRepository;
+import com.kr.matitting.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -19,6 +23,7 @@ import java.util.List;
 public class PartyScheduler {
 
     private final PartyRepository partyRepository;
+    private final NotificationService notificationService;
 
     @Scheduled(cron = "0 0 */1 * * ?", zone = "Asia/Seoul")
     public void checkEndParty() {
@@ -36,6 +41,11 @@ public class PartyScheduler {
                 party.setStatus(PartyStatus.PARTY_FINISH);
                 changeCount++;
                 partyRepository.save(party);
+
+                party.getTeamList().stream().filter(user -> user.getRole() == Role.VOLUNTEER).map(Team::getUser).forEach(user -> {
+                    notificationService.send(user, NotificationType.REVIEW, "후기를 적어주세요.", "오늘 방장님은 어땟나요? 후기를 적어주세요.");
+                });
+
             }
         }
         log.info("=== party 상태 "+ changeCount +"개 변경 완료 ===");

--- a/src/main/java/com/kr/matitting/security/SecurityConfig.java
+++ b/src/main/java/com/kr/matitting/security/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.kr.matitting.security;
 
 import com.kr.matitting.jwt.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.reactive.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -253,7 +253,7 @@ public class PartyService {
                 throw new PartyJoinException(PartyJoinExceptionType.DUPLICATION_PARTY_JOIN);
             }
             PartyJoin savedpartyJoin = partyJoinRepository.save(partyJoin);
-            notificationService.send(party.getUser(), NotificationType.PARTICIPATION_REQUEST, "파티 신청했습니다.");
+            notificationService.send(party.getUser(), NotificationType.PARTICIPATION_REQUEST, "파티 신청이 도착했어요.", "파티 신청했습니다.");
             return savedpartyJoin.getId();
         } else if (partyJoinDto.status() == PartyJoinStatus.CANCEL) {
             if (byPartyIdAndLeaderIdAndUserId.isEmpty()) {
@@ -292,10 +292,10 @@ public class PartyService {
 
             eventPublisher.publishEvent(new JoinRoomEvent(party.getId(), volunteerUser.getId()));
 
-            notificationService.send(volunteerUser, NotificationType.REQUEST_DECISION, "참가신청 수락");
+            notificationService.send(volunteerUser, NotificationType.REQUEST_DECISION, "참가신청 여부가 도착했습니다.", "참가신청 수락");
             return "Accept Request Completed";
         } else {
-            notificationService.send(volunteerUser, NotificationType.REQUEST_DECISION, "참가신청 거절");
+            notificationService.send(volunteerUser, NotificationType.REQUEST_DECISION, "참가신청 여부가 도착했습니다.","참가신청 거절");
             log.info("=== REFUSE ===");
             return "Refuse Request Completed";
         }

--- a/src/main/java/com/kr/matitting/service/ReviewService.java
+++ b/src/main/java/com/kr/matitting/service/ReviewService.java
@@ -1,0 +1,36 @@
+package com.kr.matitting.service;
+
+import com.kr.matitting.constant.NotificationType;
+import com.kr.matitting.dto.ReviewDto;
+import com.kr.matitting.entity.Review;
+import com.kr.matitting.entity.User;
+import com.kr.matitting.exception.user.UserException;
+import com.kr.matitting.exception.user.UserExceptionType;
+import com.kr.matitting.repository.ReviewRepository;
+import com.kr.matitting.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+    public void setReview(User user, ReviewDto reviewDto) {
+        User host = userRepository.findById(reviewDto.getUserId()).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
+
+        Review review = Review.builder()
+                .host(host)
+                .volunteer(user)
+                .content(reviewDto.getContent())
+                .build();
+        Review saved = reviewRepository.save(review);
+
+        notificationService.send(saved.getHost(), NotificationType.REVIEW, "후기가 도착했습니다.", saved.getContent());
+    }
+}


### PR DESCRIPTION
### 수정 사항
- sse가 unconnected 상태일 때 cache 저장되는 알림의 key값이 해제되기 이전에 생성된 emitterId의 값이라서 lastEventId보다 이전에 발생한 알림으로 간주되는 것을 cache에 알림이 저장될 때 만들어진 eventId로 교체하여 cache에 append하는 로직으로 수정하였다. 🐤 
- sendNotification()을 진행할 때 unconnected 상태면 해당 emitter는 catch()로직에 의해서 삭제되고 있다. 이후에 2번 째 알림이 발생할 때(아직 unconnected 상태) 앞에서 emitter가 삭제되어버렸기 때문에 emiiter를 불러와서 cache에 저장하는 로직 자체를 타지 못했고 알림이 누락되어 버리는 상태가 발생하여 cache에 저장하는 로직을 밖으로 빼내었고, catch()시 error log를 발생시키고 emitter를 삭제하지 않았다 🏴󠁧󠁢󠁷󠁬󠁳󠁿 
- sendLostData() 문을 실행한다는 것은 cache에 저장된 값들은 사용자에게 보내졌음을 의미한다. 그래서 sendLostData()문을 진행 후 cache를 clean()해주는 로직도 추가하였다. 🐺 

### 이슈 사항
- AOP 기능을 사용하여 핵심 비지니스 로직과 관심 로직으로 분리하여 코드를 진행하고 싶다!! 그래서 log 뿐만 아니라 알림 기능또한 관심 로직으로 분리하여 좋은 OOP 설계 및 개발을 진행하고 싶어 Custom Annotation을 만들고 AOP를 활용하여 알림 기능을 고도화 시켜보고 싶다.

근데 제가 spring sse 알림 블로그를 많이 살펴보니 어느정도 코드가 동일화 되어 있더라구요....? 뭔가 아직 제가 이해를 잘 못하고 있는것이 알림쪽을 잘 모르나봐요 ㅠ 그 많은 코드들이 다 틀리진 않았을텐대,, 허헣,,, ㅠ 해당 코드들의 동작을 보고 싶었으나 아직까지는 마땅한 블로그를 찾지 못했네요!! 조금 더 공부해보겠습니다