### PR TITLE
SSE를 활용한 알림 기능 구현 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 
 ### sql ###
 **.sql
+
+Q*.java

--- a/src/main/java/com/kr/matitting/constant/NotificationType.java
+++ b/src/main/java/com/kr/matitting/constant/NotificationType.java
@@ -1,0 +1,5 @@
+package com.kr.matitting.constant;
+
+public enum NotificationType {
+    PARTICIPATION_REQUEST, REQUEST_DECISION, REVIEW
+}

--- a/src/main/java/com/kr/matitting/controller/NotificationController.java
+++ b/src/main/java/com/kr/matitting/controller/NotificationController.java
@@ -1,0 +1,37 @@
+package com.kr.matitting.controller;
+
+import com.kr.matitting.entity.User;
+import com.kr.matitting.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @Operation(summary = "알림 구독", description = "알림을 받기 위해 SSE 통신을 연결하는 API \n\n" +
+            "Request시 Header에 'Last-Event-ID'를 넣어주어 마지막으로 받은 알림이 어디까지인지 BackEnd에게 요청")
+    @ApiResponse(responseCode = "200", description = "SSE 연결 성공")
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> subscribe(
+            @AuthenticationPrincipal User user,
+            @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId,
+            HttpServletResponse response
+    ) {
+        response.setHeader("X-Accel-Buffering", "no");
+        return ResponseEntity.ok(notificationService.subscribe(user, lastEventId));
+    }
+}

--- a/src/main/java/com/kr/matitting/dto/NotificationDto.java
+++ b/src/main/java/com/kr/matitting/dto/NotificationDto.java
@@ -1,0 +1,36 @@
+package com.kr.matitting.dto;
+
+import com.kr.matitting.constant.NotificationType;
+import com.kr.matitting.entity.Notification;
+import lombok.*;
+
+import java.time.LocalDate;
+
+public class NotificationDto {
+    @AllArgsConstructor
+    @Builder
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class Response {
+        String id;
+        String name;
+        String title;
+        String content;
+        NotificationType type;
+        String createdAt;
+
+        String lastEventId;
+        public static Response createResponse(Notification notification, String lastEventId) {
+            return Response.builder()
+                    .title(notification.getTitle())
+                    .content(notification.getContent())
+                    .id(notification.getId().toString())
+                    .name(notification.getReceiver().getNickname())
+                    .type(notification.getNotificationType())
+                    .createdAt(LocalDate.from(notification.getCreateDate()).toString())
+                    .lastEventId(lastEventId)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/kr/matitting/entity/Notification.java
+++ b/src/main/java/com/kr/matitting/entity/Notification.java
@@ -1,0 +1,34 @@
+package com.kr.matitting.entity;
+
+import com.kr.matitting.constant.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Notification extends BaseTimeEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+    private String title;
+    private String content;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User receiver;
+    @Builder
+    public Notification(User receiver, NotificationType notificationType, String title, String content) {
+        this.receiver = receiver;
+        this.notificationType = notificationType;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/kr/matitting/repository/EmitterRepository.java
+++ b/src/main/java/com/kr/matitting/repository/EmitterRepository.java
@@ -1,0 +1,21 @@
+package com.kr.matitting.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface EmitterRepository {
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+
+    void saveEventCache(String eventCacheId, Object event);
+
+    Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId);
+
+    Map<String, Object> findAllEventCacheStartWithByMemberId(String memberId);
+
+    void deleteById(String id);
+
+    void deleteAllEmitterStartWithId(String memberId);
+
+    void deleteAllEventCacheStartWithId(String memberId);
+}

--- a/src/main/java/com/kr/matitting/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/kr/matitting/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.kr.matitting.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) { // emitter를 저장
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String eventCacheId, Object event) { // 이벤트를 저장
+        eventCache.put(eventCacheId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId) { // 해당 회원과 관련된 모든 이벤트를 찾음
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithByMemberId(String memberId) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String id) { // emitter를 지움
+        emitters.remove(id);
+    }
+
+    @Override
+    public void deleteAllEmitterStartWithId(String memberId) { // 해당 회원과 관련된 모든 emitter를 지움
+        emitters.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(memberId)) {
+                        emitters.remove(key);
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void deleteAllEventCacheStartWithId(String memberId) { // 해당 회원과 관련된 모든 이벤트를 지움
+        eventCache.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(memberId)) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/kr/matitting/repository/NotificationRepository.java
+++ b/src/main/java/com/kr/matitting/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.kr.matitting.repository;
+
+import com.kr.matitting.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/kr/matitting/service/NotificationService.java
+++ b/src/main/java/com/kr/matitting/service/NotificationService.java
@@ -1,0 +1,140 @@
+package com.kr.matitting.service;
+
+import com.kr.matitting.constant.NotificationType;
+import com.kr.matitting.dto.NotificationDto;
+import com.kr.matitting.entity.Notification;
+import com.kr.matitting.entity.User;
+import com.kr.matitting.repository.EmitterRepository;
+import com.kr.matitting.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+    // 기본 타임아웃 설정
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+    private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * SSE 연결
+     * @param user
+     * @param lastEventId
+     * @return
+     */
+    public SseEmitter subscribe(User user, String lastEventId) {
+
+        String emitterId = makeTimeIncludeId(user.getId());
+
+        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        log.info("new emitter added : {}", emitter);
+        log.info("lastEventId : {}", lastEventId);
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+        emitter.onError((e) -> emitterRepository.deleteAllEmitterStartWithId(emitterId));
+
+        //503 에러 방지를 위한 더미 이벤트 전송
+        String eventId = makeTimeIncludeId(user.getId());
+        sendNotification(emitter, eventId, emitterId, "EventStream Created. [userId=" + user.getId() + "]");
+
+        if (hasLostData(lastEventId)) {
+            sendLostData(lastEventId, user, emitterId, emitter);
+        }
+
+        return emitter;
+    }
+
+    /**
+     * 고유 Key 값 생성 : emitterId, eventId 등
+     * @param userId
+     * @return
+     */
+    private String makeTimeIncludeId(Long userId) {
+        return userId + "_" + System.currentTimeMillis();
+    }
+
+    /**
+     * 알림 전송
+     * @param emitter
+     * @param eventId
+     * @param emitterId
+     * @param data
+     */
+    private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(eventId)
+                    .name("sse")
+                    .data(data)
+            );
+        } catch (IOException exception) {
+//            emitterRepository.deleteById(emitterId);
+            log.error("알림 전송에 실패했습니다.");
+        }
+    }
+
+    /**
+     * Lost된 Data 검사
+     * @param lastEventId
+     * @return
+     */
+    private boolean hasLostData(String lastEventId) {
+        return !lastEventId.isEmpty();
+    }
+
+    /**
+     * Lost Data 전송
+     * @param lastEventId
+     * @param user
+     * @param emitterId
+     * @param emitter
+     */
+    private void sendLostData(String lastEventId, User user, String emitterId, SseEmitter emitter) {
+        Map<String, Object> eventCaches = emitterRepository.findAllEventCacheStartWithByMemberId(String.valueOf(user.getId()));
+        System.out.println("eventCaches = " + eventCaches.size());
+
+        /**
+         * cache에 쌓인 데이터 send
+         */
+        eventCaches.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> sendNotification(emitter, entry.getKey(), emitterId, entry.getValue()));
+
+        /**
+         * cache 비우기
+         */
+        eventCaches.clear();
+    }
+
+    /**
+     * 알림 cache 저장 및 전송
+     * @param receiver
+     * @param notificationType
+     * @param title
+     * @param content
+     */
+    public void send(User receiver, NotificationType notificationType, String title, String content){
+        Notification notification = notificationRepository.save(new Notification(receiver, notificationType, title, content));
+
+        Long userId = receiver.getId();
+        String eventId = makeTimeIncludeId(userId);
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByMemberId(String.valueOf(userId));
+        emitterRepository.saveEventCache(eventId, NotificationDto.Response.createResponse(notification, eventId));
+
+        emitters.forEach(
+                (key, emitter) -> {
+                    sendNotification(emitter, eventId, key, NotificationDto.Response.createResponse(notification, eventId));
+                }
+        );
+    }
+}

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -44,6 +44,7 @@ public class PartyService {
     private final PartyRepository partyRepository;
     private final UserRepository userRepository;
     private final MapService mapService;
+    private final NotificationService notificationService;
 
     public ResponsePartyDetailDto getPartyInfo(User user, Long partyId) {
         Party party = partyRepository.findById(partyId).orElseThrow(() -> new PartyException(PartyExceptionType.NOT_FOUND_PARTY));
@@ -247,6 +248,8 @@ public class PartyService {
                 throw new PartyJoinException(PartyJoinExceptionType.DUPLICATION_PARTY_JOIN);
             }
             PartyJoin savedpartyJoin = partyJoinRepository.save(partyJoin);
+            notificationService.send(party.getUser(), NotificationType.PARTICIPATION_REQUEST, "파티 신청이 도착했어요.", "파티 신청했습니다.");
+
             return savedpartyJoin.getId();
         } else if (partyJoinDto.status() == PartyJoinStatus.CANCEL) {
             if (byPartyIdAndLeaderIdAndUserId.isEmpty()) {
@@ -284,10 +287,11 @@ public class PartyService {
             teamRepository.save(member);
 
             eventPublisher.publishEvent(new JoinRoomEvent(party.getId(), volunteerUser.getId()));
-
+            notificationService.send(volunteerUser, NotificationType.REQUEST_DECISION, "참가신청 여부가 도착했습니다.", "참가신청 수락");
             return "Accept Request Completed";
         } else {
             log.info("=== REFUSE ===");
+            notificationService.send(volunteerUser, NotificationType.REQUEST_DECISION, "참가신청 여부가 도착했습니다.","참가신청 거절");
             return "Refuse Request Completed";
         }
     }


### PR DESCRIPTION
### 이슈 사항
- sse가 unconnected 상태일 때 cache 저장되는 알림의 key값이 해제되기 이전에 생성된 emitterId의 값이라서 lastEventId보다 이전에 발생한 알림으로 간주되는 것을 cache에 알림이 저장될 때 만들어진 eventId로 교체하여 cache에 append하는 로직으로 수정하였다. 🐤
- sendNotification()을 진행할 때 unconnected 상태면 해당 emitter는 catch()로직에 의해서 삭제되고 있다. 이후에 2번 째 알림이 발생할 때(아직 unconnected 상태) 앞에서 emitter가 삭제되어버렸기 때문에 emiiter를 불러와서 cache에 저장하는 로직 자체를 타지 못했고 알림이 누락되어 버리는 상태가 발생하여 cache에 저장하는 로직을 밖으로 빼내었고, catch()시 error log를 발생시키고 emitter를 삭제하지 않았다 🏴󠁧󠁢󠁷󠁬󠁳󠁿
- sendLostData() 문을 실행한다는 것은 cache에 저장된 값들은 사용자에게 보내졌음을 의미한다. 그래서 sendLostData()문을 진행 후 cache를 clean()해주는 로직도 추가하였다. 🐺

### 추가 고도화 방안
- AOP 기능을 사용하여 핵심 비지니스 로직과 관심 로직으로 분리하여 코드를 진행하고 싶다!! 그래서 log 뿐만 아니라 알림 기능또한 관심 로직으로 분리하여 좋은 OOP 설계 및 개발을 진행하고 싶어 Custom Annotation을 만들고 AOP를 활용하여 알림 기능을 고도화 시켜보고 싶다.