### PR TITLE
jwt 로직 수정

### DIFF
--- a/src/main/java/com/kr/matitting/dto/ResponsePartyJoinDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponsePartyJoinDto.java
@@ -1,0 +1,12 @@
+package com.kr.matitting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResponsePartyJoinDto {
+    @Schema(description = "파티 신청 ID", example = "1")
+    private Long partyJoinId;
+}

--- a/src/main/java/com/kr/matitting/oauth2/service/OauthService.java
+++ b/src/main/java/com/kr/matitting/oauth2/service/OauthService.java
@@ -41,6 +41,8 @@ public class OauthService {
             String accessToken = jwtService.createAccessToken(user);
             String refreshToken = jwtService.createRefreshToken(user);
 
+            jwtService.updateRefreshToken(user, refreshToken);
+
             return new UserLoginDto(user.getId(), user.getRole(), accessToken, refreshToken);
         } 
         //신규유저

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -229,7 +229,7 @@ public class PartyService {
                 .build();
     }
 
-    public Long joinParty(PartyJoinDto partyJoinDto, User user) {
+    public ResponsePartyJoinDto joinParty(PartyJoinDto partyJoinDto, User user) {
         log.info("=== joinParty() start ===");
 
         Party party = partyRepository.findById(partyJoinDto.partyId()).orElseThrow(() -> new PartyJoinException(PartyJoinExceptionType.NOT_FOUND_PARTY_JOIN));
@@ -247,13 +247,13 @@ public class PartyService {
             PartyJoin savedpartyJoin = partyJoinRepository.save(partyJoin);
             notificationService.send(party.getUser(), NotificationType.PARTICIPATION_REQUEST, "파티 신청이 도착했어요.", "파티 신청했습니다.");
 
-            return savedpartyJoin.getId();
+            return new ResponsePartyJoinDto(savedpartyJoin.getId());
         } else if (partyJoinDto.status() == PartyJoinStatus.CANCEL) {
             if (byPartyIdAndLeaderIdAndUserId.isEmpty()) {
                 throw new PartyJoinException(PartyJoinExceptionType.NOT_FOUND_PARTY_JOIN);
             }
             partyJoinRepository.delete(byPartyIdAndLeaderIdAndUserId.get());
-            return byPartyIdAndLeaderIdAndUserId.get().getId();
+            return new ResponsePartyJoinDto(byPartyIdAndLeaderIdAndUserId.get().getId());
         } else {
             throw new PartyJoinException(PartyJoinExceptionType.WRONG_STATUS);
         }


### PR DESCRIPTION
### 수정 사항
- 소셜 로그인 로직을 수정하면서 누락 코드 추가 (소셜 로그인 시 refreshToken을 발급 후 redis에 socialId:refreshToken 값을 저장하여 cache로 관리하는 코드 누락) 🐛 