### PR TITLE
03.24 주간회의 후 로직 추가

### DIFF
--- a/src/main/java/com/kr/matitting/controller/ReviewController.java
+++ b/src/main/java/com/kr/matitting/controller/ReviewController.java
@@ -36,6 +36,16 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.getReviewList(user, reviewType));
     }
 
+    @Operation(summary = "방장 리뷰 리스트 조회", description = "방장의 리뷰 리스트를 불러오는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "방장 리뷰 리스트 조회 성공", content = @Content(schema = @Schema(implementation = ReviewGetRes.class))),
+            @ApiResponse(responseCode = "404(600)", description = "회원 정보가 없습니다.", content = @Content(schema = @Schema(implementation = UserException.class)))
+    })
+    @GetMapping("/host")
+    public ResponseEntity<List<ReviewGetRes>> getHostReviewList(@RequestParam Long hostId) {
+        return ResponseEntity.ok(reviewService.getHostReviewList(hostId));
+    }
+
     @Operation(summary = "리뷰 상세 조회", description = "리뷰 상세 정보를 불러오는 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "리뷰 상세 조회 성공", content = @Content(schema = @Schema(implementation = ReviewInfoRes.class))),

--- a/src/main/java/com/kr/matitting/dto/ReviewGetRes.java
+++ b/src/main/java/com/kr/matitting/dto/ReviewGetRes.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import static java.lang.Math.*;
+
 @Getter
 @AllArgsConstructor
 public class ReviewGetRes {
@@ -28,7 +30,7 @@ public class ReviewGetRes {
                 user.getImgUrl(),
                 user.getNickname(),
                 review.getRating(),
-                review.getContent().substring(0, Math.max(review.getContent().length(),9)) + " ...",
+                review.getContent().substring(0, min(review.getContent().length(),9)) + " ...",
                 review.getImgUrl());
     }
 }

--- a/src/main/java/com/kr/matitting/oauth2/service/OauthService.java
+++ b/src/main/java/com/kr/matitting/oauth2/service/OauthService.java
@@ -50,7 +50,7 @@ public class OauthService {
 
     private UserLoginDto saveNewUser(OauthMember request) {
         Random random = new Random();
-        User newUser = new User(request.getEmail(),
+        User newUser = new User(request.getSocialId(),
                 request.getOauthProvider(),
                 request.getEmail(),
                 NICKNAME[random.nextInt(18)] + random.nextInt(0, 999),

--- a/src/main/java/com/kr/matitting/service/ReviewService.java
+++ b/src/main/java/com/kr/matitting/service/ReviewService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,6 +45,14 @@ public class ReviewService {
                 return user.getSendReviews().stream().map(review -> ReviewGetRes.toDto(review, review.getReceiver())).toList();
         }
         return null;
+    }
+
+    /**
+     * 방장 리뷰 조회
+     */
+    public List<ReviewGetRes> getHostReviewList(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
+        return user.getReceivedReviews().stream().map(review -> ReviewGetRes.toDto(review, user)).sorted(Comparator.comparing(ReviewGetRes::getReviewId).reversed()).toList();
     }
 
     /**

--- a/src/test/java/com/kr/matitting/service/ReviewServiceTest.java
+++ b/src/test/java/com/kr/matitting/service/ReviewServiceTest.java
@@ -68,6 +68,8 @@ class ReviewServiceTest {
                 .imgUrl("왈왈.jpg")
                 .gender(MALE)
                 .role(Role.USER)
+                .receivedReviews(new ArrayList<>())
+                .sendReviews(new ArrayList<>())
                 .build();
         user1.setReceivedReviews(new ArrayList<>());
         user1.setSendReviews(new ArrayList<>());
@@ -339,6 +341,35 @@ class ReviewServiceTest {
         assertThat(findReview.getIsSelfReview()).isTrue();
         assertThat(findReview1.getNickname()).isEqualTo(user2.getNickname());
         assertThat(findReview1.getIsSelfReview()).isFalse();
+    }
+
+    @DisplayName("방장 후기 조회 성공")
+    @Test
+    void 방장_후기조회_성공() {
+        //given
+        ReviewCreateReq reviewCreateReq = new ReviewCreateReq(user1.getId(), party1.getId(), "방장님 멋져요.", 50, "추억사진.jpg");
+        ReviewCreateRes review1 = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review2 = reviewService.createReview(reviewCreateReq, user3);
+
+        //when
+        List<ReviewGetRes> hostReviewList = reviewService.getHostReviewList(user1.getId());
+
+        //then
+        assertThat(hostReviewList.size()).isEqualTo(2);
+        assertThat(hostReviewList.get(0).getReviewId()).isEqualTo(review2.getReviewId());
+        assertThat(hostReviewList.get(1).getReviewId()).isEqualTo(review1.getReviewId());
+    }
+
+    @DisplayName("방장 후기 조회 실패 없는 유저ID")
+    @Test
+    void 방장_후기조회_실패_없는_유저ID() {
+        //given
+        ReviewCreateReq reviewCreateReq = new ReviewCreateReq(user1.getId(), party1.getId(), "방장님 멋져요.", 50, "추억사진.jpg");
+        ReviewCreateRes review1 = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review2 = reviewService.createReview(reviewCreateReq, user3);
+
+        //when, then
+        assertThrows(UserException.class, () -> reviewService.getHostReviewList(user1.getId() + 100L));
     }
 }
 


### PR DESCRIPTION
### 추가사항
- 방장 리뷰 조회 API 생성 : 파티원들은 파티 방장의 리뷰를 볼 수 있도록 리뷰 List를 Response 해주는 API 추가 🍵 
- 파티 상세 조회 시 방장의 후기 최대 3개 return : 파티 상세 페이지에서 방장의 리뷰를 간단히 볼 수 있도록 view, 더욱 궁금하면 방장의 리뷰를 조회하여 봄 🦙 