### PR TITLE
파티 신청 현황 페이징 기능 구현

### DIFF
--- a/src/main/java/com/kr/matitting/controller/PartyController.java
+++ b/src/main/java/com/kr/matitting/controller/PartyController.java
@@ -116,14 +116,14 @@ public class PartyController {
                                                     "※ ACCEPT or CANCEL 입력이 아닐 시에는 Exception"
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "파티 참가 신청 성공", content = @Content(schema = @Schema(implementation = ResponsePartyJoinDto.class))),
+        @ApiResponse(responseCode = "200", description = "파티 참가 신청 성공", content = @Content(schema = @Schema(implementation = ResponseCreatePartyJoinDto.class))),
         @ApiResponse(responseCode = "404(600)", description = "회원 정보가 없습니다.", content = @Content(schema = @Schema(implementation = UserException.class))),
         @ApiResponse(responseCode = "404(700)", description = "참가 신청 정보가 없습니다.", content = @Content(schema = @Schema(implementation = PartyJoinException.class))),
         @ApiResponse(responseCode = "404(800)", description = "파티 정보가 없습니다.", content = @Content(schema = @Schema(implementation = PartyException.class))),
         @ApiResponse(responseCode = "403(602)", description = "요청한 회원정보가 잘못되었습니다.", content = @Content(schema = @Schema(implementation = UserException.class))),
     })
     @PostMapping("/participation")
-    public ResponseEntity<ResponsePartyJoinDto> JoinParty(@RequestBody @Valid PartyJoinDto partyJoinDto, @AuthenticationPrincipal User user) {
+    public ResponseEntity<ResponseCreatePartyJoinDto> JoinParty(@RequestBody @Valid PartyJoinDto partyJoinDto, @AuthenticationPrincipal User user) {
         return ResponseEntity.ok(partyService.joinParty(partyJoinDto, user));
     }
 
@@ -172,9 +172,11 @@ public class PartyController {
         @ApiResponse(responseCode = "403(602)", description = "권한이 없는 사용자, Role이 유효하지 않음", content = @Content(schema = @Schema(implementation = UserException.class))),
     })
     @GetMapping("/party-join")
-    public ResponseEntity<List<InvitationRequestDto>> getJoinList(@AuthenticationPrincipal User user,
-                                         @NotNull @RequestParam Role role) {
-        List<InvitationRequestDto> invitationRequestDtos = partyService.getJoinList(user, role);
-        return ResponseEntity.ok(invitationRequestDtos);
+    public ResponseEntity<ResponseGetPartyJoinDto> getJoinList(@AuthenticationPrincipal User user,
+                                                               @RequestParam(defaultValue = "5") Integer size,
+                                                               @RequestParam Long lastId,
+                                                               @NotNull @RequestParam Role role) {
+        ResponseGetPartyJoinDto joinList = partyService.getJoinList(user, role, size, lastId);
+        return ResponseEntity.ok(joinList);
     }
 }

--- a/src/main/java/com/kr/matitting/dto/InvitationRequestDto.java
+++ b/src/main/java/com/kr/matitting/dto/InvitationRequestDto.java
@@ -14,6 +14,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -44,6 +46,8 @@ public class InvitationRequestDto {
     @Schema(description = "사용자 나이", nullable = false, example = "26")
     @NotNull
     private Integer userAge;
+    @Schema(description = "신청 일자", example = "2024-03-29T10:15:30.123456789")
+    private LocalDateTime createAt;
 
     public static InvitationRequestDto toDto(PartyJoin partyJoin, User user, Role role) {
         Party party = partyJoin.getParty();
@@ -57,6 +61,7 @@ public class InvitationRequestDto {
                 .partyAge(party.getAge())
                 .userGender(user.getGender())
                 .userAge(user.getAge())
+                .createAt(partyJoin.getCreateDate())
                 .build();
     }
 }

--- a/src/main/java/com/kr/matitting/dto/ResponseCreatePartyJoinDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseCreatePartyJoinDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ResponsePartyJoinDto {
+public class ResponseCreatePartyJoinDto {
     @Schema(description = "파티 신청 ID", example = "1")
     private Long partyJoinId;
 }

--- a/src/main/java/com/kr/matitting/dto/ResponseGetPartyJoinDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseGetPartyJoinDto.java
@@ -1,0 +1,13 @@
+package com.kr.matitting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ResponseGetPartyJoinDto {
+    private List<InvitationRequestDto> partyList;
+    private ResponseNoOffsetDto pageInfo;
+}

--- a/src/main/java/com/kr/matitting/dto/ResponseNoOffsetDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseNoOffsetDto.java
@@ -1,0 +1,17 @@
+package com.kr.matitting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+@Schema(description = "no offset Response")
+@Getter
+public class ResponseNoOffsetDto {
+    @Schema(description = "마지막 Id", nullable = false, example = "10")
+    private Long lastId;
+    @Schema(description = "다음 페이지 유무", nullable = false, example = "true")
+    private boolean hasNext;
+
+    public ResponseNoOffsetDto(Long lastId, boolean hasNext) {
+        this.lastId = lastId;
+        this.hasNext = hasNext;
+    }
+}

--- a/src/main/java/com/kr/matitting/dto/ReviewCreateReq.java
+++ b/src/main/java/com/kr/matitting/dto/ReviewCreateReq.java
@@ -22,7 +22,7 @@ public class ReviewCreateReq {
     @NotBlank
     private String content; //리뷰 내용
     @NotNull
-    @Max(100) @Min(0)
+    @Max(5) @Min(0)
     private Integer rating; //온도
     private List<String> imgUrl; //리뷰 이미지
 }

--- a/src/main/java/com/kr/matitting/dto/ReviewGetRes.java
+++ b/src/main/java/com/kr/matitting/dto/ReviewGetRes.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static java.lang.Math.*;
 
@@ -24,7 +25,7 @@ public class ReviewGetRes {
     @Schema(description = "리뷰 내용", example = "방장님 멋져요.")
     private String content;
     @Schema(description = "리뷰 첨부사진", example = "돈까스사진.jpg")
-    private String reviewImg;
+    private List<String> reviewImg;
     @Schema(description = "리뷰 생성일자", example = "2024-03-28T14:45:30.123456789")
     private LocalDateTime createAt;
 

--- a/src/main/java/com/kr/matitting/dto/ReviewInfoRes.java
+++ b/src/main/java/com/kr/matitting/dto/ReviewInfoRes.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -21,7 +22,7 @@ public class ReviewInfoRes {
     @Schema(description = "review rating", example = "50")
     private Integer rating;
     @Schema(description = "리뷰 첨부사진", example = "돈까스사진.jpg")
-    private String reviewImg;
+    private List<String> reviewImg;
     @Schema(description = "리뷰 쓴 날짜", example = "2024-02-28")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate createAt;
@@ -29,7 +30,7 @@ public class ReviewInfoRes {
     private Boolean isSelfReview;
 
     public static ReviewInfoRes toDto(Review review, User user) {
-        Boolean selfReview = user == null ? false : review.getReviewer().getId().equals(user.getId());
+        Boolean selfReview = user != null && review.getReviewer().getId().equals(user.getId());
 
         return new ReviewInfoRes(
                 review.getId(),

--- a/src/main/java/com/kr/matitting/repository/PartyJoinRepository.java
+++ b/src/main/java/com/kr/matitting/repository/PartyJoinRepository.java
@@ -10,11 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
-    List<PartyJoin> findByLeaderId(Long leaderId);
-    List<PartyJoin> findByPartyIdAndLeaderId(Long partyId, Long leaderId);
     Optional<PartyJoin> findByPartyIdAndUserId(Long partyId, Long userId);
     Optional<PartyJoin> findByPartyIdAndLeaderIdAndUserId(Long partyId, Long leaderId, Long userId);
-
-    List<PartyJoin> findAllByLeaderId(Long userId);
-    List<PartyJoin> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/kr/matitting/repository/PartyJoinRepositoryCustom.java
+++ b/src/main/java/com/kr/matitting/repository/PartyJoinRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.kr.matitting.repository;
+
+import com.kr.matitting.constant.Role;
+import com.kr.matitting.entity.PartyJoin;
+import com.kr.matitting.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface PartyJoinRepositoryCustom {
+    Slice<PartyJoin> getPartyJoin(Pageable pageable, Long lastPartyJoinId, User user, Role role);
+}

--- a/src/main/java/com/kr/matitting/repository/PartyJoinRepositoryCustomImpl.java
+++ b/src/main/java/com/kr/matitting/repository/PartyJoinRepositoryCustomImpl.java
@@ -1,0 +1,68 @@
+package com.kr.matitting.repository;
+
+import com.kr.matitting.constant.Role;
+import com.kr.matitting.entity.PartyJoin;
+import com.kr.matitting.entity.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.kr.matitting.entity.QParty.party;
+import static com.kr.matitting.entity.QPartyJoin.partyJoin;
+
+@Repository
+@RequiredArgsConstructor
+public class PartyJoinRepositoryCustomImpl implements PartyJoinRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<PartyJoin> getPartyJoin(Pageable pageable, Long lastPartyJoinId, User user, Role role) {
+        return getPartyJoinList(pageable, lastPartyJoinId, user, role);
+    }
+    private Slice<PartyJoin> getPartyJoinList(Pageable pageable, Long lastPartyJoinId, User user, Role role) {
+        JPAQuery<PartyJoin> jpaQuery = queryFactory
+                .select(partyJoin)
+                .from(partyJoin);
+
+        if (role.equals(Role.HOST))
+            jpaQuery.where(leaderIdEq(user.getId()));
+        else
+            jpaQuery.where(volunteerEq(user.getId()));
+        jpaQuery.where(ltPartyJoinId(lastPartyJoinId));
+
+        List<PartyJoin> partyJoinList = jpaQuery
+                .limit(pageable.getPageSize())
+                .orderBy(partyJoin.createDate.desc())
+                .fetch();
+        return checkLastPage(partyJoinList, pageable);
+    }
+
+    private BooleanExpression leaderIdEq(Long userId) {
+        return partyJoin.leaderId.eq(userId);
+    }
+
+    private BooleanExpression volunteerEq(Long userId) {
+        return partyJoin.userId.eq(userId);
+    }
+
+    private BooleanExpression ltPartyJoinId(Long lastPartyJoinId) {
+        return lastPartyJoinId == 0L ? null : party.id.lt(lastPartyJoinId);
+    }
+
+    private Slice<PartyJoin> checkLastPage(List<PartyJoin> partyJoinList, Pageable pageable) {
+        boolean hasNext = false;
+        if (partyJoinList.size() > pageable.getPageSize()) {
+            hasNext = true;
+            partyJoinList.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(partyJoinList, pageable, hasNext);
+    }
+}

--- a/src/test/java/com/kr/matitting/service/UserServiceTest.java
+++ b/src/test/java/com/kr/matitting/service/UserServiceTest.java
@@ -10,7 +10,6 @@ import com.kr.matitting.jwt.service.JwtService;
 import com.kr.matitting.redis.RedisUtil;
 import com.kr.matitting.repository.PartyRepository;
 import com.kr.matitting.repository.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -169,7 +168,7 @@ class UserServiceTest {
         this.party4 = partyRepository.save(party4);
     }
 
-    ResponsePartyJoinDto partyJoin(Long partyId, User volunteer, PartyJoinStatus status) {
+    ResponseCreatePartyJoinDto partyJoin(Long partyId, User volunteer, PartyJoinStatus status) {
         PartyJoinDto partyJoinDto = new PartyJoinDto(partyId, status);
         return partyService.joinParty(partyJoinDto, volunteer);
     }
@@ -296,8 +295,8 @@ class UserServiceTest {
         ResponseCreatePartyDto responseCreatePartyDto3 = partyCreate(user2);
         ResponseCreatePartyDto responseCreatePartyDto4 = partyCreate(user2);
 
-        ResponsePartyJoinDto responsePartyJoinDto1 = partyJoin(responseCreatePartyDto3.getPartyId(), user1, PartyJoinStatus.APPLY);
-        ResponsePartyJoinDto responsePartyJoinDto2 = partyJoin(responseCreatePartyDto4.getPartyId(), user1, PartyJoinStatus.APPLY);
+        ResponseCreatePartyJoinDto responseCreatePartyJoinDto1 = partyJoin(responseCreatePartyDto3.getPartyId(), user1, PartyJoinStatus.APPLY);
+        ResponseCreatePartyJoinDto responseCreatePartyJoinDto2 = partyJoin(responseCreatePartyDto4.getPartyId(), user1, PartyJoinStatus.APPLY);
         PartyDecisionDto partyDecisionDto1 = new PartyDecisionDto(responseCreatePartyDto3.getPartyId(), user1.getNickname(), PartyDecision.ACCEPT);
         PartyDecisionDto partyDecisionDto2 = new PartyDecisionDto(responseCreatePartyDto4.getPartyId(), user1.getNickname(), PartyDecision.ACCEPT);
         partyService.decideUser(partyDecisionDto1, user2);


### PR DESCRIPTION
### 추가 사항
- 파티 현황을 조회할 떄 no offset 기능을 활용하여 최신순으로 정렬 후 List를 반환하는 로직 구현 완료 🍶

### 수정 사항
- 파티 Join Response Dto 수정 🗡️
- 테스트 코드 수정 🍵
- 신청 일자 Column 추가 📅