### PR TITLE
[mod] 파티 모집 완료 시 팀원들에게 파티 모집 완료 알림

### DIFF
--- a/src/main/java/com/kr/matitting/constant/NotificationType.java
+++ b/src/main/java/com/kr/matitting/constant/NotificationType.java
@@ -1,5 +1,5 @@
 package com.kr.matitting.constant;
 
 public enum NotificationType {
-    PARTICIPATION_REQUEST, REQUEST_DECISION, REVIEW
+    PARTICIPATION_REQUEST, REQUEST_DECISION, PARTY_FINISH, REVIEW
 }

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -128,6 +128,14 @@ public class PartyService {
             party.setPartyPlaceName(partyUpdateDto.partyPlaceName());
         }
         if (partyUpdateDto.status() != null) {
+            if (partyUpdateDto.status().equals(PartyStatus.PARTY_FINISH)){
+                party.getTeamList()
+                        .stream()
+                        .map(Team::getUser)
+                        .filter(teamUser -> teamUser.getId() != user.getId())
+                        .forEach(teamUser -> notificationService.send(teamUser, NotificationType.PARTY_FINISH, "파티 모집 완료", party.getPartyTitle() + " 파티 모집이 완료되었습니다."));
+            }
+
             party.setStatus(partyUpdateDto.status());
         }
         if (partyUpdateDto.thumbnail() != null) {


### PR DESCRIPTION
### 추가 사항
- 방장이 파티 상태를 모집 완료로 업데이트 시 팀원들에게 파티 모집 완료 알림 전송 ⚗️ 