### PR TITLE
파티 상태 변경 수정

### DIFF
--- a/src/main/java/com/kr/matitting/constant/NotificationType.java
+++ b/src/main/java/com/kr/matitting/constant/NotificationType.java
@@ -1,5 +1,5 @@
 package com.kr.matitting.constant;
 
 public enum NotificationType {
-    PARTICIPATION_REQUEST, REQUEST_DECISION, PARTY_FINISH, REVIEW
+    PARTICIPATION_REQUEST, REQUEST_DECISION, RECRUIT_FINISH, REVIEW
 }

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -125,12 +125,12 @@ public class PartyService {
             party.setPartyPlaceName(partyUpdateDto.partyPlaceName());
         }
         if (partyUpdateDto.status() != null) {
-            if (partyUpdateDto.status().equals(PartyStatus.PARTY_FINISH)){
+            if (partyUpdateDto.status().equals(PartyStatus.RECRUIT_FINISH)){
                 party.getTeamList()
                         .stream()
                         .map(Team::getUser)
                         .filter(teamUser -> teamUser.getId() != user.getId())
-                        .forEach(teamUser -> notificationService.send(teamUser, NotificationType.PARTY_FINISH, "파티 모집 완료", party.getPartyTitle() + " 파티 모집이 완료되었습니다."));
+                        .forEach(teamUser -> notificationService.send(teamUser, NotificationType.RECRUIT_FINISH, "파티 모집 완료", party.getPartyTitle() + " 파티 모집이 완료되었습니다."));
             }
 
             party.setStatus(partyUpdateDto.status());


### PR DESCRIPTION
### 수정 사항
- 사용자가 파티를 마감으로 상태를 변경할 때 알림을 보내는것에서 모집 완료로 변경 시 알림을 보내는 로직으로 수정 💅 