### PR TITLE
영속성 컨텍스트 문제 해결 [OSIV 설정 변경]

### DIFF
--- a/src/main/java/com/kr/matitting/config/WebConfig.java
+++ b/src/main/java/com/kr/matitting/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.kr.matitting.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public FilterRegistrationBean<OpenEntityManagerInViewFilter> openEntityManagerInViewFilter() {
+        FilterRegistrationBean<OpenEntityManagerInViewFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new OpenEntityManagerInViewFilter());
+        registrationBean.addUrlPatterns("/*"); // 모든 URL에 필터 적용
+        registrationBean.addInitParameter("excludePatterns", "/api/chat/**,/chat/room,/room/enter/**,/api/chat-rooms**"); // 제외할 패턴 설정
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/kr/matitting/entity/PartyJoin.java
+++ b/src/main/java/com/kr/matitting/entity/PartyJoin.java
@@ -16,7 +16,7 @@ public class PartyJoin extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "join_id")
     private Long id;
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "party_id")
     private Party party;
     @Column(name = "leader_id", nullable = false)

--- a/src/main/java/com/kr/matitting/entity/User.java
+++ b/src/main/java/com/kr/matitting/entity/User.java
@@ -59,13 +59,13 @@ public class User extends BaseTimeEntity{
     @Column(nullable = false)
     private Role role; //신규유저 or 기존유저
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Party> partyList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "reviewer", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "reviewer", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Review> sendReviews = new ArrayList<>();
 
-    @OneToMany(mappedBy = "receiver", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "receiver", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Review> receivedReviews = new ArrayList<>();
 
     public User(String socialId, OauthProvider oauthProvider, String email, String nickname, Integer age, String imgUrl, Gender gender, Role role) {

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -4,6 +4,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        enable_lazy_load_no_trans: true
 
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
### 수정 사항 #119 
- OSIV 설정을 통해서 영속성 객체의 범위를 View까지 늘려 연관관계 매핑을 LAZY로 활용할 수 있도록 수정하였다 💯 

### OSIV 선택 이유
- 맛있팅 서비스는 전체적으로 Entity끼리의 의존성이 높고 트래픽이 적은 비지니스 로직이 주를 이루고 있다. 이러한 경우에는 OSIV를 활용해서 LAZY 전략을 사용할 때의 개발 복잡성을 줄이고 편리한 유지보수의 장점을 가져갈 수 있다고 생각하였다. 💡 
- 다만 채팅같은 실시간 로직에는 OSIV가 맞지 않다고 판단되어 채팅 URL은 설정을 false로 변경했다. 🪑 
### reference
- https://sudo-minz.tistory.com/158
- https://velog.io/@dhk22/SpringBoot-JPA-API%EC%84%A4%EA%B3%84-OSIV
- https://hstory0208.tistory.com/entry/SpringJPA-OSIV-%EC%A0%84%EB%9E%B5%EC%9D%B4%EB%9E%80-%EC%96%B8%EC%A0%9C-%EC%82%AC%EC%9A%A9%ED%95%B4%EC%95%BC-%ED%95%A0%EA%B9%8C