### PR TITLE
알림 데이터 전송 포맷 수정

### DIFF
--- a/src/main/java/com/kr/matitting/service/NotificationService.java
+++ b/src/main/java/com/kr/matitting/service/NotificationService.java
@@ -74,8 +74,8 @@ public class NotificationService {
         try {
             emitter.send(SseEmitter.event()
                     .id(eventId)
-                    .name("sse")
-                    .data(data)
+                    .name("event: sse")
+                    .data("data:" + data)
             );
         } catch (IOException exception) {
 //            emitterRepository.deleteById(emitterId);


### PR DESCRIPTION
### 수정 사항
- 현석님께서 데이터 전송을 할 때, 데이터 포맷이 맞지 않아서 front에서 onmessage() 메소드를 사용할 때 error가 발생한다고 전달해주셨고 그에 따라서 알림을 전송할 때 포맷을 다음과 같이 변경하였다. [event: {message}, data: {data}] 🏑 

## reference
- https://stackoverflow.com/questions/28673371/eventsource-onmessage-is-not-working-where-onopen-and-onerror-works-proper