### PR TITLE
방장 리뷰 리스트 조회 페이지네이션 적용, 후기생성 request 수정

### DIFF
--- a/src/main/java/com/kr/matitting/controller/ReviewController.java
+++ b/src/main/java/com/kr/matitting/controller/ReviewController.java
@@ -42,8 +42,10 @@ public class ReviewController {
             @ApiResponse(responseCode = "404(600)", description = "회원 정보가 없습니다.", content = @Content(schema = @Schema(implementation = UserException.class)))
     })
     @GetMapping("/host")
-    public ResponseEntity<List<ReviewGetRes>> getHostReviewList(@RequestParam Long hostId) {
-        return ResponseEntity.ok(reviewService.getHostReviewList(hostId));
+    public ResponseEntity<ReviewListRes> getHostReviewList(@RequestParam Long hostId,
+                                                           @RequestParam Long lastId,
+                                                           @RequestParam(defaultValue = "5") Integer size) {
+        return ResponseEntity.ok(reviewService.getHostReviewList(hostId, lastId, size));
     }
 
     @Operation(summary = "리뷰 상세 조회", description = "리뷰 상세 정보를 불러오는 API")

--- a/src/main/java/com/kr/matitting/dto/ReviewCreateReq.java
+++ b/src/main/java/com/kr/matitting/dto/ReviewCreateReq.java
@@ -17,7 +17,6 @@ import java.util.List;
 @Schema(description = "리뷰 생성 DTO")
 public class ReviewCreateReq {
     @NotNull
-    private Long userId; //방장 id
     private Long partyId; //파티 id
     @NotBlank
     private String content; //리뷰 내용

--- a/src/main/java/com/kr/matitting/dto/ReviewListRes.java
+++ b/src/main/java/com/kr/matitting/dto/ReviewListRes.java
@@ -1,0 +1,14 @@
+package com.kr.matitting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ReviewListRes {
+    private List<ReviewGetRes> reviewGetResList;
+
+    private ResponseNoOffsetDto noOffsetDto;
+}

--- a/src/main/java/com/kr/matitting/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/kr/matitting/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.kr.matitting.repository;
+
+import com.kr.matitting.entity.Review;
+import com.kr.matitting.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ReviewRepositoryCustom {
+    Slice<Review> getHostReview(Pageable pageable, Long lastPartyReviewId, User user);
+}

--- a/src/main/java/com/kr/matitting/repository/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/kr/matitting/repository/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,54 @@
+package com.kr.matitting.repository;
+
+import com.kr.matitting.entity.Review;
+import com.kr.matitting.entity.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.kr.matitting.entity.QReview.review;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Review> getHostReview(Pageable pageable, Long lastPartyReviewId, User user){
+        return getHostReviewList(pageable, lastPartyReviewId, user);
+    }
+
+    private Slice<Review> getHostReviewList(Pageable pageable, Long lastHostReviewId, User user){
+        List<Review> hostReviewList = queryFactory
+                .select(review)
+                .from(review)
+                .where(review.receiver.eq(user),
+                        ltHostReviewId(lastHostReviewId))
+                .limit(pageable.getPageSize()+1)
+                .orderBy(review.createDate.desc())
+                .fetch();
+
+        return checkLastPage(hostReviewList, pageable);
+    }
+
+    private BooleanExpression ltHostReviewId(Long lastHostReviewId) {
+        return lastHostReviewId == 0L ? null : review.id.lt(lastHostReviewId);
+    }
+
+    private Slice<Review> checkLastPage(List<Review> hostReviewList, Pageable pageable) {
+        boolean hasNext = false;
+        if (hostReviewList.size() > pageable.getPageSize()) {
+            hasNext = true;
+            hostReviewList.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(hostReviewList, pageable, hasNext);
+    }
+
+}

--- a/src/main/java/com/kr/matitting/service/ReviewService.java
+++ b/src/main/java/com/kr/matitting/service/ReviewService.java
@@ -13,15 +13,17 @@ import com.kr.matitting.exception.user.UserException;
 import com.kr.matitting.exception.user.UserExceptionType;
 import com.kr.matitting.repository.PartyRepository;
 import com.kr.matitting.repository.ReviewRepository;
+import com.kr.matitting.repository.ReviewRepositoryCustom;
 import com.kr.matitting.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +35,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final PartyRepository partyRepository;
     private final UserRepository userRepository;
+    private final ReviewRepositoryCustom reviewRepositoryCustom;
 
     /**
      * 리뷰 리스트 조회
@@ -42,15 +45,24 @@ public class ReviewService {
             return user.getReceivedReviews().stream().map(review -> ReviewGetRes.toDto(review, review.getReviewer())).toList();
         else
             return user.getSendReviews().stream().map(review -> ReviewGetRes.toDto(review, review.getReceiver())).toList();
-
     }
-
     /**
      * 방장 리뷰 조회
      */
-    public List<ReviewGetRes> getHostReviewList(Long userId) {
+    public ReviewListRes getHostReviewList(Long userId, Long lastId, Integer size) {
         User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
-        return user.getReceivedReviews().stream().map(review -> ReviewGetRes.toDto(review, user)).sorted(Comparator.comparing(ReviewGetRes::getReviewId).reversed()).toList();
+
+        PageRequest pageable = PageRequest.of(0, size);
+        Slice<Review> hostReview = reviewRepositoryCustom.getHostReview(pageable, lastId, user);
+
+        List<ReviewGetRes> reviewGetRes = hostReview.getContent().stream().map(review -> ReviewGetRes.toDto(review, review.getReviewer())).toList();
+        ResponseNoOffsetDto pageInfoDto = new ResponseNoOffsetDto(getLastId(reviewGetRes), hostReview.hasNext());
+
+        return new ReviewListRes(reviewGetRes, pageInfoDto);
+    }
+
+    private Long getLastId(List<ReviewGetRes> reviewGetRes) {
+        return reviewGetRes.isEmpty() ? null : reviewGetRes.get(reviewGetRes.size() - 1).getReviewId();
     }
 
     /**

--- a/src/main/java/com/kr/matitting/service/ReviewService.java
+++ b/src/main/java/com/kr/matitting/service/ReviewService.java
@@ -77,16 +77,17 @@ public class ReviewService {
      * 리뷰 생성
      */
     public ReviewCreateRes createReview(ReviewCreateReq reviewCreateReq, User user) {
-        Optional<Review> byReview = reviewRepository.findByParty_IdAndReceiver_IdAndReviewer_Id(reviewCreateReq.getPartyId(), reviewCreateReq.getUserId(), user.getId());
+        Party party = partyRepository.findById(reviewCreateReq.getPartyId()).orElseThrow(() -> new PartyException(PartyExceptionType.NOT_FOUND_PARTY));
+
+        Optional<Review> byReview = reviewRepository.findByParty_IdAndReceiver_IdAndReviewer_Id(party.getId(), party.getUser().getId(), user.getId());
         if (byReview.isPresent())
             throw new ReviewException(ReviewExceptionType.DUPLICATION_REVIEW);
 
-        Party party = partyRepository.findById(reviewCreateReq.getPartyId()).orElseThrow(() -> new PartyException(PartyExceptionType.NOT_FOUND_PARTY));
 
         if (party.getPartyTime().isAfter(LocalDateTime.now()))
             throw new ReviewException(ReviewExceptionType.NOT_START_PARTY);
 
-        User receiver = userRepository.findById(reviewCreateReq.getUserId()).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
+        User receiver = userRepository.findById(party.getId()).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
         Review review = Review.builder()
                 .content(reviewCreateReq.getContent())
                 .rating(reviewCreateReq.getRating())


### PR DESCRIPTION
### 수정사항
- 방장 리뷰 리스트 조회기능에 페이지네이션을 추가했다.
- 후기 생성 request에서 userId를 삭제했다. request의 partyId를 통해 userId를 get하는 방식으로 변경함