### PR TITLE
채팅 관련 FE 요청사항 반영 & 채팅 기록 DB 저장 로직 추가

### DIFF
--- a/src/main/java/com/kr/matitting/controller/ChatController.java
+++ b/src/main/java/com/kr/matitting/controller/ChatController.java
@@ -6,11 +6,14 @@ import com.kr.matitting.dto.ResponseChatListDto;
 import com.kr.matitting.entity.User;
 import com.kr.matitting.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,8 +27,14 @@ public class ChatController {
     private final ChatService chatService;
 
     @Operation(summary = "채팅 기록 가져오기", description = "채팅 기록 조회 API \n\n" +
-            "[로직 설명] \n\n" +
-            "채팅방 id에 해당하는 채팅방의 채팅 기록을 조회하여 리턴합니다.")
+                                                        "[로직 설명] \n\n" +
+                                                        "채팅방 id에 해당하는 채팅방의 채팅 기록을 조회하여 리턴합니다.")
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK",
+                    content = {
+                            @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseChatListDto.class)))})
+    })
     @GetMapping("/{roomId}")
     public ResponseEntity<ResponseChatListDto> getChats(@PathVariable Long roomId,
                                                         @AuthenticationPrincipal User user,

--- a/src/main/java/com/kr/matitting/dto/ResponseChatDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseChatDto.java
@@ -14,7 +14,6 @@ public class ResponseChatDto {
     private Long senderId;
     private String nickname;
     private String message;
+    private String imgUrl;
     private LocalDateTime createAt;
-
-
 }

--- a/src/main/java/com/kr/matitting/dto/ResponseChatPageInfoDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseChatPageInfoDto.java
@@ -2,16 +2,16 @@ package com.kr.matitting.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
-@Schema(description = "메인페이지 페이지 정보 Response")
+@Schema(description = "채팅 페이지 정보 Response")
 @Getter
 public class ResponseChatPageInfoDto {
-    @Schema(description = "이전에 조회한 party id", nullable = false, example = "10")
-    private Long lastPartyId;
+    @Schema(description = "이전에 조회한 chat id", nullable = false, example = "10")
+    private Long lastChatId;
     @Schema(description = "다음 페이지 유무", nullable = false, example = "true")
     private boolean hasNext;
 
-    public ResponseChatPageInfoDto(Long newLastPartyId, boolean hasNext) {
-        this.lastPartyId = newLastPartyId;
+    public ResponseChatPageInfoDto(Long newChatId, boolean hasNext) {
+        this.lastChatId = newChatId;
         this.hasNext = hasNext;
     }
 }

--- a/src/main/java/com/kr/matitting/dto/ResponseChatRoomDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseChatRoomDto.java
@@ -20,8 +20,15 @@ public class ResponseChatRoomDto {
     private Long roomId;
     @Schema(description = "채팅방 제목")
     private String title;
+    @Schema(description = "파티 썸네일")
+    private String thumbnail;
+    @Schema(description = "마지막 메시지")
+    private String lastMessage;
     @Schema(description = "채팅방 마지막 전송시간")
     private LocalDateTime lastUpdate;
+
+    @Schema(description = "채팅방 마지막 전송시간")
+    private LocalDateTime lastMessageTime;
 
     public ResponseChatRoomDto(ChatRoom chatRoom) {
         this.roomId = chatRoom.getId();

--- a/src/main/java/com/kr/matitting/dto/ResponseChatRoomUserDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseChatRoomUserDto.java
@@ -20,10 +20,16 @@ public class ResponseChatRoomUserDto {
     private Role role;
     @Schema(description = "채팅유저의 닉네임")
     private String nickname;
+    @Schema(description = "유저 프로필 사진")
+    private String userProfileImg;
+    @Schema(description = "방장여부")
+    private boolean isLeader;
 
     public ResponseChatRoomUserDto(ChatUser chatUser) {
         this.chatUserId = chatUser.getId();
         this.role = chatUser.getUserRole();
         this.nickname = chatUser.getNickname();
+        this.userProfileImg = chatUser.getUser().getImgUrl();
+        this.isLeader = chatUser.getUserRole().equals(Role.HOST);
     }
 }

--- a/src/main/java/com/kr/matitting/entity/Chat.java
+++ b/src/main/java/com/kr/matitting/entity/Chat.java
@@ -31,4 +31,11 @@ public class Chat {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
+
+    public Chat(ChatUser chatUser, ChatRoom chatRoom, String message){
+        this.sendUser = chatUser;
+        this.message = message;
+        this.chatRoom = chatRoom;
+    }
+
 }

--- a/src/main/java/com/kr/matitting/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/kr/matitting/repository/ChatRoomRepositoryImpl.java
@@ -3,26 +3,20 @@ package com.kr.matitting.repository;
 import com.kr.matitting.dto.ResponseChatPageInfoDto;
 import com.kr.matitting.dto.ResponseChatRoomDto;
 import com.kr.matitting.dto.ResponseChatRoomListDto;
-import com.kr.matitting.dto.ResponsePageInfoDto;
-import com.kr.matitting.entity.*;
-import com.kr.matitting.exception.chat.ChatException;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import com.kr.matitting.entity.Chat;
+import com.kr.matitting.entity.ChatRoom;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
+import static com.kr.matitting.entity.QChat.chat;
 import static com.kr.matitting.entity.QChatRoom.chatRoom;
 import static com.kr.matitting.entity.QChatUser.chatUser;
-import static com.kr.matitting.entity.QParty.party;
 
 @Repository
 @RequiredArgsConstructor
@@ -49,6 +43,9 @@ public class ChatRoomRepositoryImpl {
                 .map(chatRoom -> ResponseChatRoomDto.builder()
                         .roomId(chatRoom.getId())
                         .title(chatRoom.getTitle())
+                        .thumbnail(chatRoom.getParty().getThumbnail())
+                        .lastMessage(findLastMessage(chatRoom) == null ? null : findLastMessage(chatRoom).getMessage())
+                        .lastMessageTime(findLastMessage(chatRoom) == null ? null : findLastMessage(chatRoom).getCreateDate())
                         .lastUpdate(chatRoom.getModifiedDate())
                         .build())
                 .toList();
@@ -65,6 +62,15 @@ public class ChatRoomRepositoryImpl {
 
         return new ResponseChatPageInfoDto(lastPartyId, hasNext);
 
+    }
+
+    private Chat findLastMessage(ChatRoom chatRoom) {
+        return queryFactory
+                .select(chat)
+                .from(chat)
+                .where(chat.chatRoom.eq(chatRoom))
+                .orderBy(chat.createDate.desc())
+                .fetchFirst();
     }
 }
 


### PR DESCRIPTION
### 수정사항

1. response 추가 

- 유저가 참여중인 채팅방 조회 API("/api/chat-rooms") response
: 파티 썸네일, 마지막 메시지, 마지막 메시지 시간 추가
- 특정 채팅방 정보 조회 API ("/api/chat-rooms/{chatRoomId}") response
: 유저 프로필 이미지 추가
- 채팅방 내 유저 정보 조회 API("/api/chat-rooms/user/{roomId}") response
: 유저 프로필 이미지, 본인이 방장인지 확인할 수 있는 값 추가

2. 채팅 메시지 DB 저장