### PR TITLE
알림 구독 시 Null 값 이슈 해결

### DIFF
--- a/src/main/java/com/kr/matitting/dto/NotificationDto.java
+++ b/src/main/java/com/kr/matitting/dto/NotificationDto.java
@@ -49,6 +49,8 @@ public class NotificationDto {
                     .sender(notification.getSender().getNickname())
                     .type(notification.getNotificationType())
                     .createdAt(notification.getCreateDate().toString())
+                    .partyId(notification.getParty().getId())
+                    .hostId(notification.getParty().getUser().getId())
                     .build();
         }
     }

--- a/src/main/java/com/kr/matitting/entity/Notification.java
+++ b/src/main/java/com/kr/matitting/entity/Notification.java
@@ -30,13 +30,19 @@ public class Notification extends BaseTimeEntity{
     @JoinColumn(name = "sender_id")
     private User sender;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id")
+    private Party party;
+
     @Builder
-    public Notification(User receiver, User sender, NotificationType notificationType, String title, String content, String eventId) {
+    public Notification(User receiver, User sender, NotificationType notificationType, String title, String content, String eventId, Party party) {
+
         this.receiver = receiver;
         this.sender = sender;
         this.notificationType = notificationType;
         this.title = title;
         this.content = content;
         this.eventId = eventId;
+        this.party = party;
     }
 }

--- a/src/main/java/com/kr/matitting/service/NotificationService.java
+++ b/src/main/java/com/kr/matitting/service/NotificationService.java
@@ -139,7 +139,7 @@ public class NotificationService {
         Long userId = receiver.getId();
         String eventId = makeTimeIncludeId(userId);
 
-        Notification notification = notificationRepository.save(new Notification(receiver, sender, notificationType, title, content, eventId));
+        Notification notification = notificationRepository.save(new Notification(receiver, sender, notificationType, title, content, eventId, party));
 
         if (receiver.getReceiveNotifications() == null)
             receiver.setReceiveNotifications(new ArrayList<>());


### PR DESCRIPTION
### 문제 상황
- 알림을 구독할 때 Last-Event-Id가 없다면 이전에 받은 알림을 모두 전송해주는 과정에서 partyId와 hostId는 불필요하다고 생각하여 null 처리를 해놓았지만, front에서 해당 info가 필요하다고 판단하였다 🐛 

### 수정 사항
- 알림 entity에 party를 @ManyToOne 관계 매핑을 진행한 후, partyId, hostId를 채워 Response 하였다 💯 