### PR TITLE
JPA/ could not initialize proxy - no Session 이슈 수정

### DIFF
--- a/src/main/java/com/kr/matitting/controller/ChatController.java
+++ b/src/main/java/com/kr/matitting/controller/ChatController.java
@@ -3,7 +3,6 @@ package com.kr.matitting.controller;
 import com.kr.matitting.dto.ChatEvictDto;
 import com.kr.matitting.dto.ChatMessageDto;
 import com.kr.matitting.dto.ResponseChatListDto;
-import com.kr.matitting.entity.User;
 import com.kr.matitting.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -42,12 +41,12 @@ public class ChatController {
     })
     @GetMapping("/{roomId}")
     public ResponseEntity<ResponseChatListDto> getChats(@PathVariable Long roomId,
-                                                        @AuthenticationPrincipal User user,
+                                                        @AuthenticationPrincipal Long userId,
                                                         @RequestParam(value = "size", defaultValue = "10", required = false) Integer size,
                                                         @RequestParam(value = "page", defaultValue = "0", required = false) Integer page
                                                         ) {
         PageRequest pageable = PageRequest.of(page, size);
-        ResponseChatListDto responseChatListDto = chatService.getChats(user.getId(), roomId, pageable);
+        ResponseChatListDto responseChatListDto = chatService.getChats(userId, roomId, pageable);
         return ResponseEntity.ok(responseChatListDto);
     }
 
@@ -66,7 +65,7 @@ public class ChatController {
     @DeleteMapping("/{roomId}")
     public void evictUser(@PathVariable Long roomId,
                           @RequestBody ChatEvictDto chatEvictDto,
-                          @AuthenticationPrincipal User user) {
-        chatService.evictUser(user.getId(), chatEvictDto.getTargetChatUserId(), roomId);
+                          @AuthenticationPrincipal Long userId) {
+        chatService.evictUser(userId, chatEvictDto.getTargetChatUserId(), roomId);
     }
 }

--- a/src/main/java/com/kr/matitting/controller/ChatRoomController.java
+++ b/src/main/java/com/kr/matitting/controller/ChatRoomController.java
@@ -2,7 +2,6 @@ package com.kr.matitting.controller;
 
 import com.kr.matitting.dto.ResponseChatRoomInfoDto;
 import com.kr.matitting.dto.ResponseChatRoomListDto;
-import com.kr.matitting.entity.User;
 import com.kr.matitting.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -38,12 +37,12 @@ public class ChatRoomController {
                             @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseChatRoomListDto.class)))})
     })
     @GetMapping
-    public ResponseEntity<ResponseChatRoomListDto> getAllRooms(@AuthenticationPrincipal User user,
+    public ResponseEntity<ResponseChatRoomListDto> getAllRooms(@AuthenticationPrincipal Long userId,
                                                                @RequestParam(value = "size", defaultValue = "10", required = false) Integer size,
                                                                @RequestParam(value = "page", defaultValue = "0", required = false) Integer page
                                                                 ) {
         Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(chatService.getChatRooms(user.getId(), pageable));
+        return ResponseEntity.ok(chatService.getChatRooms(userId, pageable));
     }
 
     @Operation(summary = "채팅방의 정보조회", description = "채팅방의 정보조회 API \n\n" +
@@ -56,9 +55,9 @@ public class ChatRoomController {
     })
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<ResponseChatRoomInfoDto> getChatRoomInfo(@PathVariable Long chatRoomId,
-                                                                    @AuthenticationPrincipal User user){
+                                                                    @AuthenticationPrincipal Long userId){
 
-        return ResponseEntity.ok(chatService.getChatRoomInfo(chatRoomId, user.getId()));
+        return ResponseEntity.ok(chatService.getChatRoomInfo(chatRoomId, userId));
     }
 
     @Operation(summary = "내 채팅방 검색", description = "내 채팅방 검색 API \n\n" +
@@ -77,12 +76,12 @@ public class ChatRoomController {
                             @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseChatRoomListDto.class)))})
     })
     @GetMapping("/search")
-    public ResponseEntity<ResponseChatRoomListDto> getChatRoomsByTitleSearch(@AuthenticationPrincipal User user,
+    public ResponseEntity<ResponseChatRoomListDto> getChatRoomsByTitleSearch(@AuthenticationPrincipal Long userId,
                                                                            @RequestParam(value ="title") String searchTitle,
                                                                            @RequestParam(value = "size", defaultValue = "10", required = false) Integer size,
                                                                            @RequestParam(value = "page", defaultValue = "0", required = false) Integer page){
         Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(chatService.getChatRoomsByTitleSearch(user.getId(), pageable, searchTitle));
+        return ResponseEntity.ok(chatService.getChatRoomsByTitleSearch(userId, pageable, searchTitle));
     }
 
 }

--- a/src/main/java/com/kr/matitting/controller/NotificationController.java
+++ b/src/main/java/com/kr/matitting/controller/NotificationController.java
@@ -1,10 +1,7 @@
 package com.kr.matitting.controller;
 
-import com.kr.matitting.entity.User;
 import com.kr.matitting.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -26,11 +23,11 @@ public class NotificationController {
             "Request시 Header에 'Last-Event-ID'를 넣어주어 마지막으로 받은 알림이 어디까지인지 BackEnd에게 요청")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> subscribe(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal Long userId,
             @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId,
             HttpServletResponse response
     ) {
         response.setHeader("X-Accel-Buffering", "no");
-        return ResponseEntity.ok(notificationService.subscribe(user, lastEventId));
+        return ResponseEntity.ok(notificationService.subscribe(userId, lastEventId));
     }
 }

--- a/src/main/java/com/kr/matitting/controller/OAuthController.java
+++ b/src/main/java/com/kr/matitting/controller/OAuthController.java
@@ -128,9 +128,9 @@ public class OAuthController {
         @ApiResponse(responseCode = "401(1102)", description = "AccessToken 검증 실패\n\n AccessToken 값이 유효하지 않거나 Expired 됐을 때 발생", content = @Content(schema = @Schema(implementation = TokenException.class)))
     })
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletRequest request, @AuthenticationPrincipal User user) {
+    public ResponseEntity<String> logout(HttpServletRequest request, @AuthenticationPrincipal Long userId) {
         String accessToken = jwtService.extractToken(request);
-        userService.logout(accessToken, user);
+        userService.logout(accessToken, userId);
         return ResponseEntity.ok("logout Success");
     }
 
@@ -149,9 +149,9 @@ public class OAuthController {
         @ApiResponse(responseCode = "401(1102)", description = "AccessToken 검증 실패\n\n AccessToken 값이 유효하지 않거나 Expired 됐을 때 발생", content = @Content(schema = @Schema(implementation = TokenException.class)))
     })
     @DeleteMapping("/withdraw")
-    public ResponseEntity<String> withdraw(HttpServletRequest request, @AuthenticationPrincipal User user) {
+    public ResponseEntity<String> withdraw(HttpServletRequest request, @AuthenticationPrincipal Long userId) {
         String accessToken = jwtService.extractToken(request);
-        userService.withdraw(accessToken, user);
+        userService.withdraw(accessToken, userId);
         
         return ResponseEntity.ok("withdraw Success");
     }

--- a/src/main/java/com/kr/matitting/controller/PartyController.java
+++ b/src/main/java/com/kr/matitting/controller/PartyController.java
@@ -2,7 +2,6 @@ package com.kr.matitting.controller;
 
 import com.kr.matitting.constant.Role;
 import com.kr.matitting.dto.*;
-import com.kr.matitting.entity.User;
 import com.kr.matitting.exception.Map.MapException;
 import com.kr.matitting.exception.Map.MapExceptionType;
 import com.kr.matitting.exception.party.PartyException;
@@ -24,8 +23,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,10 +50,10 @@ public class PartyController {
 
     @PostMapping
     public ResponseEntity<ResponseCreatePartyDto> createParty(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal Long userId,
             @RequestBody @Valid PartyCreateDto request
     ) {
-        ResponseCreatePartyDto responseCreatePartyDto = partyService.createParty(user, request);
+        ResponseCreatePartyDto responseCreatePartyDto = partyService.createParty(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseCreatePartyDto);
     }
 
@@ -77,8 +74,8 @@ public class PartyController {
         @ApiResponse(responseCode = "403(602)", description = "요청한 회원정보가 잘못되었습니다.", content = @Content(schema = @Schema(implementation = UserException.class))),
     })
     @PatchMapping("/{partyId}")
-    public ResponseEntity<String> updateParty(@AuthenticationPrincipal User user, @RequestBody PartyUpdateDto partyUpdateDto, @PathVariable Long partyId) {
-        partyService.partyUpdate(user, partyUpdateDto, partyId);
+    public ResponseEntity<String> updateParty(@AuthenticationPrincipal Long userId, @RequestBody PartyUpdateDto partyUpdateDto, @PathVariable Long partyId) {
+        partyService.partyUpdate(userId, partyUpdateDto, partyId);
         return ResponseEntity.ok("Success Party update");
     }
 
@@ -94,8 +91,8 @@ public class PartyController {
         @ApiResponse(responseCode = "404(800)", description = "파티 정보가 없습니다.", content = @Content(schema = @Schema(implementation = PartyException.class)))
     })
     @GetMapping("/{partyId}")
-    public ResponseEntity<ResponsePartyDetailDto> partyDetail(@AuthenticationPrincipal User user, @PathVariable Long partyId) {
-        ResponsePartyDetailDto partyInfo = partyService.getPartyInfo(user, partyId);
+    public ResponseEntity<ResponsePartyDetailDto> partyDetail(@AuthenticationPrincipal Long userId, @PathVariable Long partyId) {
+        ResponsePartyDetailDto partyInfo = partyService.getPartyInfo(userId, partyId);
         return ResponseEntity.ok(partyInfo);
     }
 
@@ -106,8 +103,8 @@ public class PartyController {
         @ApiResponse(responseCode = "404(800)", description = "파티 정보가 없습니다.", content = @Content(schema = @Schema(implementation = PartyException.class)))
     })
     @DeleteMapping("/{partyId}")
-    public ResponseEntity<String> partyDelete(@AuthenticationPrincipal User user, @PathVariable Long partyId) {
-        partyService.deleteParty(user, partyId);
+    public ResponseEntity<String> partyDelete(@AuthenticationPrincipal Long userId, @PathVariable Long partyId) {
+        partyService.deleteParty(userId, partyId);
         return ResponseEntity.ok("Success Party Delete");
     }
 
@@ -127,8 +124,8 @@ public class PartyController {
         @ApiResponse(responseCode = "403(602)", description = "요청한 회원정보가 잘못되었습니다.", content = @Content(schema = @Schema(implementation = UserException.class))),
     })
     @PostMapping("/participation")
-    public ResponseEntity<ResponseCreatePartyJoinDto> JoinParty(@RequestBody @Valid PartyJoinDto partyJoinDto, @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(partyService.joinParty(partyJoinDto, user));
+    public ResponseEntity<ResponseCreatePartyJoinDto> JoinParty(@RequestBody @Valid PartyJoinDto partyJoinDto, @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(partyService.joinParty(partyJoinDto, userId));
     }
 
     @Operation(summary = "파티 참가 수락/거절", description = "참여 수락/거절 API \n\n " +
@@ -147,8 +144,8 @@ public class PartyController {
         @ApiResponse(responseCode = "403(602)", description = "요청한 회원정보가 잘못되었습니다.", content = @Content(schema = @Schema(implementation = UserException.class))),
     })
     @PostMapping("/decision")
-    public ResponseEntity<String> AcceptRefuseParty(@RequestBody @Valid PartyDecisionDto partyDecisionDto, @AuthenticationPrincipal User user) {
-        String result = partyService.decideUser(partyDecisionDto, user);
+    public ResponseEntity<String> AcceptRefuseParty(@RequestBody @Valid PartyDecisionDto partyDecisionDto, @AuthenticationPrincipal Long userId) {
+        String result = partyService.decideUser(partyDecisionDto, userId);
         return ResponseEntity.ok(result);
     }
 
@@ -168,10 +165,10 @@ public class PartyController {
                                                 "\t sort : 최신순으로 정렬하여 response하도록 설정 request X \n\n")
     @ApiResponse(responseCode = "200", description = "파티 현황 조회 성공", content = @Content(schema = @Schema(implementation = ResponseMyParty.class)))
     @GetMapping("/party-status")
-    public ResponseEntity<ResponseMyParty> myPartyList(@AuthenticationPrincipal User user,
+    public ResponseEntity<ResponseMyParty> myPartyList(@AuthenticationPrincipal Long userId,
                                                        @PageableDefault Pageable pageable,
                                                        @Valid PartyStatusReq partyStatusReq) {
-        return ResponseEntity.ok(userService.getMyPartyList(user, partyStatusReq, pageable));
+        return ResponseEntity.ok(userService.getMyPartyList(userId, partyStatusReq, pageable));
     }
 
     @Operation(summary = "파티 신청 현황", description = "실시간 파티 현황 API \n\n" +
@@ -186,10 +183,10 @@ public class PartyController {
         @ApiResponse(responseCode = "403(602)", description = "권한이 없는 사용자, Role이 유효하지 않음", content = @Content(schema = @Schema(implementation = UserException.class))),
     })
     @GetMapping("/party-join")
-    public ResponseEntity<ResponseGetPartyJoinDto> getJoinList(@AuthenticationPrincipal User user,
+    public ResponseEntity<ResponseGetPartyJoinDto> getJoinList(@AuthenticationPrincipal Long userId,
                                                                @PageableDefault Pageable pageable,
                                                                @NotNull @RequestParam Role role) {
-        ResponseGetPartyJoinDto joinList = partyService.getJoinList(user, role, pageable);
+        ResponseGetPartyJoinDto joinList = partyService.getJoinList(userId, role, pageable);
         return ResponseEntity.ok(joinList);
     }
 }

--- a/src/main/java/com/kr/matitting/controller/ReviewController.java
+++ b/src/main/java/com/kr/matitting/controller/ReviewController.java
@@ -2,7 +2,6 @@ package com.kr.matitting.controller;
 
 import com.kr.matitting.constant.ReviewType;
 import com.kr.matitting.dto.*;
-import com.kr.matitting.entity.User;
 import com.kr.matitting.exception.party.PartyException;
 import com.kr.matitting.exception.reivew.ReviewException;
 import com.kr.matitting.exception.user.UserException;
@@ -35,10 +34,10 @@ public class ReviewController {
             @ApiResponse(responseCode = "200", description = "리뷰 리스트 조회 성공", content = @Content(schema = @Schema(implementation = ResponseReviewList.class))),
     })
     @GetMapping
-    public ResponseEntity<ResponseReviewList> getReviewList(@AuthenticationPrincipal User user,
+    public ResponseEntity<ResponseReviewList> getReviewList(@AuthenticationPrincipal Long userId,
                                                             @RequestParam ReviewType reviewType,
                                                             @PageableDefault Pageable pageable) {
-        return ResponseEntity.ok(reviewService.getReviewList(user, reviewType, pageable));
+        return ResponseEntity.ok(reviewService.getReviewList(userId, reviewType, pageable));
     }
 
     @Operation(summary = "방장 리뷰 리스트 조회", description = "방장의 리뷰 리스트를 불러오는 API \n\n" +
@@ -61,8 +60,8 @@ public class ReviewController {
             @ApiResponse(responseCode = "404(1700)", description = "리뷰 정보가 없음", content = @Content(schema = @Schema(implementation = ReviewException.class)))
     })
     @GetMapping("/{reviewId}")
-    public ResponseEntity<ReviewInfoRes> getReview(@AuthenticationPrincipal User user, @PathVariable Long reviewId) {
-        return ResponseEntity.ok(reviewService.getReview(user, reviewId));
+    public ResponseEntity<ReviewInfoRes> getReview(@AuthenticationPrincipal Long userId, @PathVariable Long reviewId) {
+        return ResponseEntity.ok(reviewService.getReview(userId, reviewId));
     }
 
     @Operation(summary = "리뷰 작성", description = "방장에게 리뷰를 작성하는 API")
@@ -74,8 +73,8 @@ public class ReviewController {
             @ApiResponse(responseCode = "409(1702)", description = "작성한 리뷰가 이미 존재", content = @Content(schema = @Schema(implementation = ReviewException.class)))
     })
     @PostMapping
-    public ResponseEntity<ReviewCreateRes> createReview(@RequestBody ReviewCreateReq reviewCreateReq, @AuthenticationPrincipal User user) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(reviewService.createReview(reviewCreateReq, user));
+    public ResponseEntity<ReviewCreateRes> createReview(@RequestBody ReviewCreateReq reviewCreateReq, @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(reviewService.createReview(reviewCreateReq, userId));
     }
 
     @Operation(summary = "리뷰 수정", description = "작성한 리뷰를 수정하는 API")
@@ -85,8 +84,8 @@ public class ReviewController {
             @ApiResponse(responseCode = "404(1700)", description = "리뷰 정보가 없음", content = @Content(schema = @Schema(implementation = ReviewException.class)))
     })
     @PatchMapping
-    public ResponseEntity<?> updateReview(@RequestBody ReviewUpdateReq reviewUpdateReq, @AuthenticationPrincipal User user) {
-        reviewService.updateReview(reviewUpdateReq, user);
+    public ResponseEntity<?> updateReview(@RequestBody ReviewUpdateReq reviewUpdateReq, @AuthenticationPrincipal Long userId) {
+        reviewService.updateReview(reviewUpdateReq, userId);
         return ResponseEntity.ok(null);
     }
 
@@ -97,8 +96,8 @@ public class ReviewController {
             @ApiResponse(responseCode = "404(1700)", description = "리뷰 정보가 없음", content = @Content(schema = @Schema(implementation = ReviewException.class)))
     })
     @DeleteMapping
-    public ResponseEntity<?> deleteReview(@RequestBody ReviewDeleteReq reviewDeleteReq, @AuthenticationPrincipal User user) {
-        reviewService.deleteReview(reviewDeleteReq, user);
+    public ResponseEntity<?> deleteReview(@RequestBody ReviewDeleteReq reviewDeleteReq, @AuthenticationPrincipal Long userId) {
+        reviewService.deleteReview(reviewDeleteReq, userId);
         return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/com/kr/matitting/controller/UserController.java
+++ b/src/main/java/com/kr/matitting/controller/UserController.java
@@ -2,7 +2,6 @@ package com.kr.matitting.controller;
 
 import com.kr.matitting.dto.ResponseMyInfo;
 import com.kr.matitting.dto.UserUpdateDto;
-import com.kr.matitting.entity.User;
 import com.kr.matitting.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,8 +28,8 @@ public class UserController {
         @ApiResponse(responseCode = "200", description = "내 프로필 조회 성공", content = @Content(schema = @Schema(implementation = ResponseMyInfo.class)))
     })
     @GetMapping
-    public ResponseEntity<ResponseMyInfo> myProfile(@AuthenticationPrincipal User user) {
-        ResponseMyInfo myInfo = userService.getMyInfo(user);
+    public ResponseEntity<ResponseMyInfo> myProfile(@AuthenticationPrincipal Long userId) {
+        ResponseMyInfo myInfo = userService.getMyInfo(userId);
         return ResponseEntity.ok(myInfo);
     }
 
@@ -44,8 +43,8 @@ public class UserController {
         @ApiResponse(responseCode = "200", description = "프로필 업데이트 성공", content = @Content(schema = @Schema(implementation = String.class)))
     })
     @PatchMapping
-    public ResponseEntity<String> myProfileUpdate(@RequestBody UserUpdateDto userUpdateDto, @AuthenticationPrincipal User user) {
-        userService.update(user, userUpdateDto);
+    public ResponseEntity<String> myProfileUpdate(@RequestBody UserUpdateDto userUpdateDto, @AuthenticationPrincipal Long userId) {
+        userService.update(userId, userUpdateDto);
         return ResponseEntity.ok("Success Profile Update");
     }
 }

--- a/src/main/java/com/kr/matitting/controller/testController.java
+++ b/src/main/java/com/kr/matitting/controller/testController.java
@@ -19,7 +19,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 @Controller
 @RequiredArgsConstructor
@@ -110,8 +112,14 @@ public class testController {
             "    - 파티 생성\n\n" +
             "    - 사용자1 파티에 참가 신청 \n\n"
     )
-    @GetMapping("/matitting3")
+    @PostMapping("/matitting3")
     public ResponseEntity<ResponseDummyDataDto> test(HttpServletResponse response) {
+        Optional<User> bySocialId_01 = userRepository.findBySocialId("3035953918");
+        Optional<User> bySocialId_02 = userRepository.findBySocialId("213312213");
+
+        bySocialId_01.ifPresent(user -> userRepository.deleteById(user.getId()));
+        bySocialId_02.ifPresent(user -> userRepository.deleteById(user.getId()));
+
         User user1 = User.builder()
                 .socialId("3035953918")
                 .oauthProvider(OauthProvider.KAKAO)
@@ -221,6 +229,14 @@ public class testController {
             "\t속한 파티 -> 파티1, 파티2")
     @PostMapping("/matitting4")
     public ResponseEntity<Map<String, Object>> testPartyStatus() {
+        Optional<User> bySocialId_01 = userRepository.findBySocialId("1");
+        Optional<User> bySocialId_02 = userRepository.findBySocialId("2");
+        Optional<User> bySocialId_03 = userRepository.findBySocialId("3");
+
+        bySocialId_01.ifPresent(user -> userRepository.deleteById(user.getId()));
+        bySocialId_02.ifPresent(user -> userRepository.deleteById(user.getId()));
+        bySocialId_03.ifPresent(user -> userRepository.deleteById(user.getId()));
+
         User user1 = User.builder()
                 .socialId("1")
                 .oauthProvider(OauthProvider.NAVER)
@@ -306,25 +322,25 @@ public class testController {
                 .thumbnail("유저2 증명사진.jpg")
                 .build();
 
-        ResponseCreatePartyDto p1 = partyService.createParty(u1, partyCreateDto1);
-        ResponseCreatePartyDto p2 = partyService.createParty(u1, partyCreateDto2);
-        ResponseCreatePartyDto p3 = partyService.createParty(u2, partyCreateDto3);
+        ResponseCreatePartyDto p1 = partyService.createParty(u1.getId(), partyCreateDto1);
+        ResponseCreatePartyDto p2 = partyService.createParty(u1.getId(), partyCreateDto2);
+        ResponseCreatePartyDto p3 = partyService.createParty(u2.getId(), partyCreateDto3);
 
         /**
          * 유저1이 파티3에 신청
          */
         PartyJoinDto partyJoinDto1 = new PartyJoinDto(p3.getPartyId(), PartyJoinStatus.APPLY, "안녕하세요 유저1입니다.");
         PartyDecisionDto partyDecisionDto1 = new PartyDecisionDto(p3.getPartyId(), "유저1", PartyDecision.ACCEPT);
-        partyService.joinParty(partyJoinDto1, u1);
-        partyService.decideUser(partyDecisionDto1, u2);
+        partyService.joinParty(partyJoinDto1, u1.getId());
+        partyService.decideUser(partyDecisionDto1, u2.getId());
 
         /**
          * 유저2이 파티1에 신청
          */
         PartyJoinDto partyJoinDto2 = new PartyJoinDto(p1.getPartyId(), PartyJoinStatus.APPLY, "안녕하세요 유저2입니다.");
         PartyDecisionDto partyDecisionDto2 = new PartyDecisionDto(p1.getPartyId(), "유저2", PartyDecision.ACCEPT);
-        partyService.joinParty(partyJoinDto2, u2);
-        partyService.decideUser(partyDecisionDto2, u1);
+        partyService.joinParty(partyJoinDto2, u2.getId());
+        partyService.decideUser(partyDecisionDto2, u1.getId());
 
         /**
          * 유저3이 파티1, 파티2에 신청
@@ -333,10 +349,10 @@ public class testController {
         PartyJoinDto partyJoinDto3_2 = new PartyJoinDto(p2.getPartyId(), PartyJoinStatus.APPLY, "안녕하세요 유저3입니다.");
         PartyDecisionDto partyDecisionDto3_1 = new PartyDecisionDto(p1.getPartyId(), "유저3", PartyDecision.ACCEPT);
         PartyDecisionDto partyDecisionDto3_2 = new PartyDecisionDto(p2.getPartyId(), "유저3", PartyDecision.ACCEPT);
-        partyService.joinParty(partyJoinDto3_1, u3);
-        partyService.joinParty(partyJoinDto3_2, u3);
-        partyService.decideUser(partyDecisionDto3_1, u1);
-        partyService.decideUser(partyDecisionDto3_2, u1);
+        partyService.joinParty(partyJoinDto3_1, u3.getId());
+        partyService.joinParty(partyJoinDto3_2, u3.getId());
+        partyService.decideUser(partyDecisionDto3_1, u1.getId());
+        partyService.decideUser(partyDecisionDto3_2, u1.getId());
 
         Map<String, Object> ResponseData = new HashMap<>();
         ResponseData.put("유저1의 ID", u1.getId());

--- a/src/main/java/com/kr/matitting/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kr/matitting/jwt/filter/JwtAuthenticationFilter.java
@@ -6,8 +6,8 @@ import com.kr.matitting.exception.token.TokenException;
 import com.kr.matitting.exception.user.UserException;
 import com.kr.matitting.exception.user.UserExceptionType;
 import com.kr.matitting.jwt.service.JwtService;
-import com.kr.matitting.repository.UserRepository;
 import com.kr.matitting.redis.RedisUtil;
+import com.kr.matitting.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,13 +23,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import java.io.IOException;
-import java.util.Collections;
-
-import static com.kr.matitting.exception.token.TokenExceptionType.*;
+import static com.kr.matitting.exception.token.TokenExceptionType.BLACK_LIST_ACCESS_TOKEN;
+import static com.kr.matitting.exception.token.TokenExceptionType.INVALID_ACCESS_TOKEN;
 
 
 @Component
@@ -73,7 +73,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 DecodedJWT decodedJWT = jwtService.isTokenValid(token);
                 String socialId = jwtService.getSocialId(decodedJWT);
                 User user = userRepository.findBySocialId(socialId).orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_USER));
-                Authentication authentication = new UsernamePasswordAuthenticationToken(user, null, Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey())));
+                Authentication authentication = new UsernamePasswordAuthenticationToken(user.getId(), null, Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey())));
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 doFilter(request, response, filterChain);

--- a/src/main/java/com/kr/matitting/repository/ChatUserRepository.java
+++ b/src/main/java/com/kr/matitting/repository/ChatUserRepository.java
@@ -10,5 +10,4 @@ public interface ChatUserRepository extends JpaRepository<ChatUser, Long> {
     Optional<ChatUser> findByUserIdAndChatRoomId(Long userId, Long roomId);
     List<ChatUser> findByChatRoomId(Long roomId);
     List<ChatUser> findByUserId(Long userId);
-    Optional<ChatUser> findByIdAndChatRoomId(Long chatUserId, Long roomId);
 }

--- a/src/main/java/com/kr/matitting/service/EntityFacade.java
+++ b/src/main/java/com/kr/matitting/service/EntityFacade.java
@@ -1,0 +1,92 @@
+package com.kr.matitting.service;
+
+import com.kr.matitting.entity.*;
+import com.kr.matitting.exception.chat.ChatException;
+import com.kr.matitting.exception.chat.ChatExceptionType;
+import com.kr.matitting.exception.party.PartyException;
+import com.kr.matitting.exception.party.PartyExceptionType;
+import com.kr.matitting.exception.partyjoin.PartyJoinException;
+import com.kr.matitting.exception.partyjoin.PartyJoinExceptionType;
+import com.kr.matitting.exception.reivew.ReviewException;
+import com.kr.matitting.exception.reivew.ReviewExceptionType;
+import com.kr.matitting.exception.team.TeamException;
+import com.kr.matitting.exception.team.TeamExceptionType;
+import com.kr.matitting.exception.user.UserException;
+import com.kr.matitting.exception.user.UserExceptionType;
+import com.kr.matitting.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class EntityFacade {
+    private final UserRepository userRepository;
+    private final PartyRepository partyRepository;
+    private final PartyJoinRepository partyJoinRepository;
+    private final PartyTeamRepository teamRepository;
+    private final ReviewRepository reviewRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatUserRepository chatUserRepository;
+
+    public User getUser(Long userId) {
+        Optional<User> userById = userRepository.findById(userId);
+        if (userById.isEmpty()) throw new UserException(UserExceptionType.NOT_FOUND_USER);
+        return userById.get();
+    }
+
+    public Party getParty(Long partyId) {
+        Optional<Party> partyById = partyRepository.findById(partyId);
+        if (partyById.isEmpty()) throw new PartyException(PartyExceptionType.NOT_FOUND_PARTY);
+        return partyById.get();
+    }
+
+    public PartyJoin getPartyJoin(Long partyJoinId) {
+        Optional<PartyJoin> partyJoinById = partyJoinRepository.findById(partyJoinId);
+        if (partyJoinById.isEmpty()) throw new PartyJoinException(PartyJoinExceptionType.NOT_FOUND_PARTY_JOIN);
+        return partyJoinById.get();
+    }
+
+    public Team getTeam(Long teamId) {
+        Optional<Team> teamById = teamRepository.findById(teamId);
+        if (teamById.isEmpty()) throw new TeamException(TeamExceptionType.NOT_FOUND_TEAM);
+        return teamById.get();
+    }
+
+    public Review getReview(Long reviewId) {
+        Optional<Review> reviewById = reviewRepository.findById(reviewId);
+        if (reviewById.isEmpty()) throw new ReviewException(ReviewExceptionType.NOT_FOUND_REVIEW);
+        return reviewById.get();
+    }
+
+    public ChatRoom getChatRoom(Long chatRoomId) {
+        Optional<ChatRoom> chatRoomById = chatRoomRepository.findById(chatRoomId);
+        if (chatRoomById.isEmpty()) throw new ChatException(ChatExceptionType.NOT_FOUND_CHAT_ROOM);
+        return chatRoomById.get();
+    }
+
+    public ChatUser getChatUser(Long chatUserId) {
+        Optional<ChatUser> chatUserById = chatUserRepository.findById(chatUserId);
+        if (chatUserById.isEmpty()) throw new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER_INFO);
+        return chatUserById.get();
+    }
+    public ChatUser getChatUserByUserIdAndChatRoomId(Long userId, Long roomId) {
+        Optional<ChatUser> chatUserByUserIdAndChatRoomId = chatUserRepository.findByUserIdAndChatRoomId(userId, roomId);
+        if (chatUserByUserIdAndChatRoomId.isEmpty())
+            throw new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER_INFO);
+        return chatUserByUserIdAndChatRoomId.get();
+    }
+    public List<ChatUser> getChatUsersByUserId(Long userId) {
+        List<ChatUser> ChatUsersByUserId = chatUserRepository.findByUserId(userId);
+        if (ChatUsersByUserId.isEmpty()) throw new ChatException(ChatExceptionType.IS_NOT_HAVE_CHAT_ROOM);
+        return ChatUsersByUserId;
+    }
+
+    public List<ChatUser> getChatUsersByRoomId(Long roomId) {
+        List<ChatUser> chatUsersByRoomId = chatUserRepository.findByChatRoomId(roomId);
+        if (chatUsersByRoomId.isEmpty()) throw new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER_INFO);
+        return chatUsersByRoomId;
+    }
+}

--- a/src/main/java/com/kr/matitting/service/NotificationService.java
+++ b/src/main/java/com/kr/matitting/service/NotificationService.java
@@ -27,14 +27,16 @@ public class NotificationService {
 
     private final EmitterRepository emitterRepository;
     private final NotificationRepository notificationRepository;
+    private final EntityFacade entityFacade;
 
     /**
      * SSE 연결
-     * @param user
+     * @param userId
      * @param lastEventId
      * @return
      */
-    public SseEmitter subscribe(User user, String lastEventId) {
+    public SseEmitter subscribe(Long userId, String lastEventId) {
+        User user = entityFacade.getUser(userId);
 
         String emitterId = makeTimeIncludeId(user.getId());
 

--- a/src/test/java/com/kr/matitting/service/MainServiceTest.java
+++ b/src/test/java/com/kr/matitting/service/MainServiceTest.java
@@ -92,7 +92,7 @@ class MainServiceTest {
                 .menu("돈까스")
                 .thumbnail("https://matitting.s3.ap-northeast-2.amazonaws.com/japanese.jpeg")
                 .build();
-        ResponseCreatePartyDto party1 = partyService.createParty(user1, partyCreateDto1);
+        ResponseCreatePartyDto party1 = partyService.createParty(user1.getId(), partyCreateDto1);
         this.party1 = partyRepository.findById(party1.getPartyId()).get();
         
         PartyCreateDto partyCreateDto2 = PartyCreateDto.builder()
@@ -109,7 +109,7 @@ class MainServiceTest {
                 .menu("뷔페")
                 .thumbnail("https://matitting.s3.ap-northeast-2.amazonaws.com/japanese.jpeg")
                 .build();
-        ResponseCreatePartyDto party2 = partyService.createParty(user1, partyCreateDto2);
+        ResponseCreatePartyDto party2 = partyService.createParty(user1.getId(), partyCreateDto2);
         this.party2 = partyRepository.findById(party2.getPartyId()).get();
 
         PartyCreateDto partyCreateDto3 = PartyCreateDto.builder()
@@ -126,7 +126,7 @@ class MainServiceTest {
                 .menu("고기")
                 .thumbnail("https://matitting.s3.ap-northeast-2.amazonaws.com/japanese.jpeg")
                 .build();
-        ResponseCreatePartyDto party3 = partyService.createParty(user1, partyCreateDto3);
+        ResponseCreatePartyDto party3 = partyService.createParty(user1.getId(), partyCreateDto3);
         this.party3 = partyRepository.findById(party3.getPartyId()).get();
 
         PartyCreateDto partyCreateDto4 = PartyCreateDto.builder()
@@ -143,7 +143,7 @@ class MainServiceTest {
                 .menu("떡볶이")
                 .thumbnail("https://matitting.s3.ap-northeast-2.amazonaws.com/japanese.jpeg")
                 .build();
-        ResponseCreatePartyDto party4 = partyService.createParty(user1, partyCreateDto4);
+        ResponseCreatePartyDto party4 = partyService.createParty(user1.getId(), partyCreateDto4);
         this.party4 = partyRepository.findById(party4.getPartyId()).get();
 
         PartyCreateDto partyCreateDto5 = PartyCreateDto.builder()
@@ -160,7 +160,7 @@ class MainServiceTest {
                 .menu("피자")
                 .thumbnail("https://matitting.s3.ap-northeast-2.amazonaws.com/japanese.jpeg")
                 .build();
-        ResponseCreatePartyDto party5 = partyService.createParty(user1, partyCreateDto5);
+        ResponseCreatePartyDto party5 = partyService.createParty(user1.getId(), partyCreateDto5);
         this.party5 = partyRepository.findById(party5.getPartyId()).get();
 
         PartyCreateDto partyCreateDto6 = PartyCreateDto.builder()
@@ -177,7 +177,7 @@ class MainServiceTest {
                 .menu("스시")
                 .thumbnail("https://matitting.s3.ap-northeast-2.amazonaws.com/japanese.jpeg")
                 .build();
-        ResponseCreatePartyDto party6 = partyService.createParty(user1, partyCreateDto6);
+        ResponseCreatePartyDto party6 = partyService.createParty(user1.getId(), partyCreateDto6);
         this.party6 = partyRepository.findById(party6.getPartyId()).get();
     }
 

--- a/src/test/java/com/kr/matitting/service/ReviewServiceTest.java
+++ b/src/test/java/com/kr/matitting/service/ReviewServiceTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -132,7 +135,7 @@ class ReviewServiceTest {
                 .menu("커피")
                 .thumbnail(null)
                 .build();
-        ResponseCreatePartyDto party = partyService.createParty(user1, partyCreateDto);
+        ResponseCreatePartyDto party = partyService.createParty(user1.getId(), partyCreateDto);
         this.party1 = partyRepository.findById(party.getPartyId()).get();
     }
 
@@ -152,7 +155,7 @@ class ReviewServiceTest {
                 .menu("커피")
                 .thumbnail(null)
                 .build();
-        return partyService.createParty(user, partyCreateDto);
+        return partyService.createParty(user.getId(), partyCreateDto);
     }
 
     @DisplayName("후기 생성 성공")
@@ -162,7 +165,7 @@ class ReviewServiceTest {
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
 
         //when
-        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2.getId());
         Optional<Review> reviewById = reviewRepository.findById(review.getReviewId());
 
         //then
@@ -181,7 +184,7 @@ class ReviewServiceTest {
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId() + 100L, "방장님 멋져요.", 50, List.of("추억사진.jpg"));
 
         //when, then
-        assertThrows(PartyException.class, () -> reviewService.createReview(reviewCreateReq, user2));
+        assertThrows(PartyException.class, () -> reviewService.createReview(reviewCreateReq, user2.getId()));
     }
 
 //    @DisplayName("후기 생성 실패 - 유저 없음")
@@ -205,7 +208,7 @@ class ReviewServiceTest {
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
 
         //when, then
-        assertThrows(ReviewException.class, () -> reviewService.createReview(reviewCreateReq, user2));
+        assertThrows(ReviewException.class, () -> reviewService.createReview(reviewCreateReq, user2.getId()));
     }
 
     @DisplayName("후기 생성 실패 - 중복 등록")
@@ -213,10 +216,10 @@ class ReviewServiceTest {
     void 후기_생성_실패_중복등록() {
         //given
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
-        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2.getId());
 
         //when, then
-        assertThrows(ReviewException.class, () -> reviewService.createReview(reviewCreateReq, user2));
+        assertThrows(ReviewException.class, () -> reviewService.createReview(reviewCreateReq, user2.getId()));
     }
 
     @DisplayName("후기 수정 성공")
@@ -224,11 +227,11 @@ class ReviewServiceTest {
     void 후기_수정_성공() {
         //given
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
-        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2.getId());
         ReviewUpdateReq reviewUpdateReq = new ReviewUpdateReq(review.getReviewId(), "방장님 이뻐요.", 80, List.of("이쁜사진.jpg"));
 
         //when
-        reviewService.updateReview(reviewUpdateReq, user2);
+        reviewService.updateReview(reviewUpdateReq, user2.getId());
         entityManager.flush();
         Optional<Review> findReview = reviewRepository.findById(review.getReviewId());
 
@@ -244,11 +247,11 @@ class ReviewServiceTest {
     void 후기_수정_실패_Role위반() {
         //given
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
-        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2.getId());
         ReviewUpdateReq reviewUpdateReq = new ReviewUpdateReq(review.getReviewId(), "방장님 이뻐요.", 80, List.of("이쁜사진.jpg"));
 
         //when, then
-        assertThrows(UserException.class, () -> reviewService.updateReview(reviewUpdateReq, user1));
+        assertThrows(UserException.class, () -> reviewService.updateReview(reviewUpdateReq, user1.getId()));
     }
 
     @DisplayName("후기 삭제 성공")
@@ -256,11 +259,11 @@ class ReviewServiceTest {
     void 후기_삭제_성공() {
         //given
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
-        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2.getId());
         ReviewDeleteReq reviewDeleteReq = new ReviewDeleteReq(review.getReviewId());
 
         //when
-        reviewService.deleteReview(reviewDeleteReq, user2);
+        reviewService.deleteReview(reviewDeleteReq, user2.getId());
         Optional<Review> byId = reviewRepository.findById(review.getReviewId());
 
         //then
@@ -272,11 +275,11 @@ class ReviewServiceTest {
     void 후기_삭제_실패_Role위반() {
         //given
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
-        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2);
+        ReviewCreateRes review = reviewService.createReview(reviewCreateReq, user2.getId());
         ReviewDeleteReq reviewDeleteReq = new ReviewDeleteReq(review.getReviewId());
 
         //when, then
-        assertThrows(UserException.class, () -> reviewService.deleteReview(reviewDeleteReq, user1));
+        assertThrows(UserException.class, () -> reviewService.deleteReview(reviewDeleteReq, user1.getId()));
     }
 
     @DisplayName("후기 리스트 조회 성공")
@@ -286,15 +289,17 @@ class ReviewServiceTest {
         ReviewCreateReq reviewCreateReq1 = new ReviewCreateReq(party1.getId(), "방장님 멋져요1.", 10, List.of("추억사진1.jpg"));
         ReviewCreateReq reviewCreateReq2 = new ReviewCreateReq(party1.getId(), "방장님 멋져요2.", 20, List.of("추억사진2.jpg"));
         ReviewCreateReq reviewCreateReq3 = new ReviewCreateReq(party1.getId(), "방장님 멋져요3.", 30, List.of("추억사진3.jpg"));
-        reviewService.createReview(reviewCreateReq1, user2);
-        reviewService.createReview(reviewCreateReq2, user3);
-        reviewService.createReview(reviewCreateReq3, user4);
+        reviewService.createReview(reviewCreateReq1, user2.getId());
+        reviewService.createReview(reviewCreateReq2, user3.getId());
+        reviewService.createReview(reviewCreateReq3, user4.getId());
+
+        Pageable pageable = PageRequest.of(0, 5);
 
         //when
-        ResponseReviewList reviewList1 = reviewService.getReviewList(user1, ReviewType.RECEIVER, 0, 5);
-        ResponseReviewList reviewList2 = reviewService.getReviewList(user2, ReviewType.SENDER, 0, 5);
-        ResponseReviewList reviewList3 = reviewService.getReviewList(user3, ReviewType.SENDER, 0, 5);
-        ResponseReviewList reviewList4 = reviewService.getReviewList(user4, ReviewType.SENDER, 0, 5);
+        ResponseReviewList reviewList1 = reviewService.getReviewList(user1.getId(), ReviewType.RECEIVER, pageable);
+        ResponseReviewList reviewList2 = reviewService.getReviewList(user2.getId(), ReviewType.SENDER, pageable);
+        ResponseReviewList reviewList3 = reviewService.getReviewList(user3.getId(), ReviewType.SENDER, pageable);
+        ResponseReviewList reviewList4 = reviewService.getReviewList(user4.getId(), ReviewType.SENDER, pageable);
 
         //then
         assertThat(reviewList1.getReviewGetResList().size()).isEqualTo(3);
@@ -314,12 +319,14 @@ class ReviewServiceTest {
         ReviewCreateReq reviewCreateReq1 = new ReviewCreateReq(party1.getId(), "방장님 멋져요1.", 10, List.of("추억사진1.jpg"));
         ReviewCreateReq reviewCreateReq2 = new ReviewCreateReq(party1.getId(), "방장님 멋져요2.", 20, List.of("추억사진2.jpg"));
         ReviewCreateReq reviewCreateReq3 = new ReviewCreateReq(party1.getId(), "방장님 멋져요3.", 30, List.of("추억사진3.jpg"));
-        reviewService.createReview(reviewCreateReq1, user2);
-        reviewService.createReview(reviewCreateReq2, user3);
-        reviewService.createReview(reviewCreateReq3, user4);
+        reviewService.createReview(reviewCreateReq1, user2.getId());
+        reviewService.createReview(reviewCreateReq2, user3.getId());
+        reviewService.createReview(reviewCreateReq3, user4.getId());
+
+        Pageable pageable = PageRequest.of(0, 3);
 
         //when, then
-        assertThrows(IllegalArgumentException.class, () -> reviewService.getReviewList(user1, ReviewType.valueOf("test"), 0, 3));
+        assertThrows(IllegalArgumentException.class, () -> reviewService.getReviewList(user1.getId(), ReviewType.valueOf("test"), pageable));
     }
 
     @DisplayName("후기 상세 조회 성공")
@@ -327,10 +334,10 @@ class ReviewServiceTest {
     void 후기_상세조회_성공() {
         //given
         ReviewCreateReq reviewCreateReq1 = new ReviewCreateReq(party1.getId(), "방장님 멋져요1.", 10, List.of("추억사진1.jpg"));
-        ReviewCreateRes review = reviewService.createReview(reviewCreateReq1, user2);
+        ReviewCreateRes review = reviewService.createReview(reviewCreateReq1, user2.getId());
 
         //when
-        ReviewInfoRes findReview = reviewService.getReview(user2, review.getReviewId());
+        ReviewInfoRes findReview = reviewService.getReview(user2.getId(), review.getReviewId());
         ReviewInfoRes findReview1 = reviewService.getReview(null, review.getReviewId());
 
         //then
@@ -349,11 +356,13 @@ class ReviewServiceTest {
     void 방장_후기조회_성공() {
         //given
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
-        ReviewCreateRes review1 = reviewService.createReview(reviewCreateReq, user2);
-        ReviewCreateRes review2 = reviewService.createReview(reviewCreateReq, user3);
+        ReviewCreateRes review1 = reviewService.createReview(reviewCreateReq, user2.getId());
+        ReviewCreateRes review2 = reviewService.createReview(reviewCreateReq, user3.getId());
+
+        Pageable pageable = PageRequest.of(0, 3);
 
         //when
-        ReviewListRes hostReviewList = reviewService.getHostReviewList(user1.getId(), review1.getReviewId(), 3);
+        ReviewListRes hostReviewList = reviewService.getHostReviewList(user1.getId(), pageable);
 
         //then
         assertThat(hostReviewList.getReviewGetResList().size()).isEqualTo(2);
@@ -366,8 +375,8 @@ class ReviewServiceTest {
     void 방장_후기조회_실패_없는_유저ID() {
         //given
         ReviewCreateReq reviewCreateReq = new ReviewCreateReq(party1.getId(), "방장님 멋져요.", 50, List.of("추억사진.jpg"));
-        ReviewCreateRes review1 = reviewService.createReview(reviewCreateReq, user2);
-        ReviewCreateRes review2 = reviewService.createReview(reviewCreateReq, user3);
+        ReviewCreateRes review1 = reviewService.createReview(reviewCreateReq, user2.getId());
+        ReviewCreateRes review2 = reviewService.createReview(reviewCreateReq, user3.getId());
 
         //when, then
         assertThrows(UserException.class, () -> reviewService.getHostReviewList(user1.getId() + 100L, 0L, 5));

--- a/src/test/java/com/kr/matitting/service/UserServiceTest.java
+++ b/src/test/java/com/kr/matitting/service/UserServiceTest.java
@@ -171,7 +171,7 @@ class UserServiceTest {
 
     ResponseCreatePartyJoinDto partyJoin(Long partyId, User volunteer, PartyJoinStatus status, String ondLineIntroduce) {
         PartyJoinDto partyJoinDto = new PartyJoinDto(partyId, status, ondLineIntroduce);
-        return partyService.joinParty(partyJoinDto, volunteer);
+        return partyService.joinParty(partyJoinDto, volunteer.getId());
     }
 
     ResponseCreatePartyDto partyCreate(User user) {
@@ -190,7 +190,7 @@ class UserServiceTest {
                 .menu("커피")
                 .thumbnail(null)
                 .build();
-        return partyService.createParty(user, partyCreateDto);
+        return partyService.createParty(user.getId(), partyCreateDto);
     }
 
     @DisplayName("내 프로필 수정 성공")
@@ -200,7 +200,7 @@ class UserServiceTest {
         UserUpdateDto userUpdateDto = new UserUpdateDto("수정했음", "수정이미지.jpg");
 
         //when
-        userService.update(user1, userUpdateDto);
+        userService.update(user1.getId(), userUpdateDto);
         Optional<User> byId = userRepository.findById(user1.getId());
 
         //then
@@ -217,7 +217,7 @@ class UserServiceTest {
         user1.setId(100L);
 
         //when, then
-        assertThrows(UserException.class, () -> userService.update(user1, userUpdateDto));
+        assertThrows(UserException.class, () -> userService.update(user1.getId(), userUpdateDto));
     }
 
     @DisplayName("로그아웃 성공")
@@ -227,7 +227,7 @@ class UserServiceTest {
         String accessToken = jwtService.createAccessToken(user1);
 
         //when
-        userService.logout(accessToken, user1);
+        userService.logout(accessToken, user1.getId());
 
         //then
         assertThat(redisUtil.getData(accessToken)).isEqualTo("logout");
@@ -240,7 +240,7 @@ class UserServiceTest {
         String accessToken = "Bearer sfdlkjfsejklfsekjlfesjlkjlksfejlsfeljsljse.fesjisfejifsfesiljsfeljifsjielefs.sfelijsfejilfesjilefsjils";
 
         //when, then
-        assertThrows(TokenException.class, () -> userService.logout(accessToken, user1));
+        assertThrows(TokenException.class, () -> userService.logout(accessToken, user1.getId()));
     }
 
     //회원탈퇴
@@ -251,7 +251,7 @@ class UserServiceTest {
         String accessToken = jwtService.createAccessToken(user1);
 
         //when
-        userService.withdraw(accessToken, user1);
+        userService.withdraw(accessToken, user1.getId());
 
         //then
         assertThat(redisUtil.getData(accessToken)).isEqualTo("logout");
@@ -265,14 +265,14 @@ class UserServiceTest {
         String accessToken = "Bearer sfdlkjfsejklfsekjlfesjlkjlksfejlsfeljsljse.fesjisfejifsfesiljsfeljifsjielefs.sfelijsfejilfesjilefsjils";
 
         //when, then
-        assertThrows(TokenException.class, () -> userService.withdraw(accessToken, user1));
+        assertThrows(TokenException.class, () -> userService.withdraw(accessToken, user1.getId()));
     }
 
     @DisplayName("내 정보 조회 성공")
     @Test
     void 내정보조회_성공() {
         //when
-        ResponseMyInfo myInfo = userService.getMyInfo(user1);
+        ResponseMyInfo myInfo = userService.getMyInfo(user1.getId());
 
         //then
         assertThat(myInfo.getUserId()).isEqualTo(user1.getId());
@@ -301,14 +301,14 @@ class UserServiceTest {
 
         PartyDecisionDto partyDecisionDto1 = new PartyDecisionDto(responseCreatePartyDto3.getPartyId(), user1.getNickname(), PartyDecision.ACCEPT);
         PartyDecisionDto partyDecisionDto2 = new PartyDecisionDto(responseCreatePartyDto4.getPartyId(), user1.getNickname(), PartyDecision.ACCEPT);
-        partyService.decideUser(partyDecisionDto1, user2);
-        partyService.decideUser(partyDecisionDto2, user2);
+        partyService.decideUser(partyDecisionDto1, user2.getId());
+        partyService.decideUser(partyDecisionDto2, user2.getId());
 
         ReviewCreateReq reviewCreateReq1 = new ReviewCreateReq(responseCreatePartyDto3.getPartyId(), "잘먹었습니다", 5, null);
         ReviewCreateReq reviewCreateReq2 = new ReviewCreateReq(responseCreatePartyDto4.getPartyId(), "못먹었습니다", 1, null);
 
-        reviewService.createReview(reviewCreateReq1, user1);
-        reviewService.createReview(reviewCreateReq2, user1);
+        reviewService.createReview(reviewCreateReq1, user1.getId());
+        reviewService.createReview(reviewCreateReq2, user1.getId());
 
         PageRequest pageRequest1 = PageRequest.of(0, 1);
         PageRequest pageRequest2 = PageRequest.of(1, 1);
@@ -317,10 +317,10 @@ class UserServiceTest {
         PartyStatusReq partyStatusReq2 = new PartyStatusReq(Role.VOLUNTEER, RECRUIT);
 
         //when
-        ResponseMyParty myPartyList1 = userService.getMyPartyList(user1, partyStatusReq1, pageRequest1);
-        ResponseMyParty myPartyList2 = userService.getMyPartyList(user1, partyStatusReq1, pageRequest2);
-        ResponseMyParty myPartyList3 = userService.getMyPartyList(user1, partyStatusReq2, pageRequest1);
-        ResponseMyParty myPartyList4 = userService.getMyPartyList(user1, partyStatusReq2, pageRequest2);
+        ResponseMyParty myPartyList1 = userService.getMyPartyList(user1.getId(), partyStatusReq1, pageRequest1);
+        ResponseMyParty myPartyList2 = userService.getMyPartyList(user1.getId(), partyStatusReq1, pageRequest2);
+        ResponseMyParty myPartyList3 = userService.getMyPartyList(user1.getId(), partyStatusReq2, pageRequest1);
+        ResponseMyParty myPartyList4 = userService.getMyPartyList(user1.getId(), partyStatusReq2, pageRequest2);
 
         //then
         assertThat(myPartyList1.getPartyList().size()).isEqualTo(1);


### PR DESCRIPTION
### 문제 상황
- @Transactional을 동작할 수 없는 JwtAuthenticationFilter에서 User를 FindBy하여 ContextHold에 넣고 있다보니, Controller, Service까지 Proxy 객체가 세션을 유지하지 못하는 이슈가 발생했다 😢 

### 해결 방법
- ContextHold에 userId를 넣고 Service Layer에서 findBy를 통일시키는 방법으로 이로 인해서 @Transactional 안에서 Entity조회가 이루어지게 되고, Fetch.LAZY 전략을 구현 가능하게 한다.