### PR TITLE
FE 요청사항 수정 및 채팅 로직 오류 수정

### DIFF
--- a/src/main/java/com/kr/matitting/constant/MessageType.java
+++ b/src/main/java/com/kr/matitting/constant/MessageType.java
@@ -1,5 +1,5 @@
 package com.kr.matitting.constant;
 
 public enum MessageType {
-    ENTER, TALK
+    ENTER, TALK, SYSTEM, EXIT
 }

--- a/src/main/java/com/kr/matitting/controller/testController.java
+++ b/src/main/java/com/kr/matitting/controller/testController.java
@@ -3,9 +3,7 @@ package com.kr.matitting.controller;
 import ch.qos.logback.core.model.Model;
 import com.kr.matitting.constant.*;
 import com.kr.matitting.dto.*;
-import com.kr.matitting.entity.Party;
-import com.kr.matitting.entity.PartyJoin;
-import com.kr.matitting.entity.User;
+import com.kr.matitting.entity.*;
 import com.kr.matitting.jwt.service.JwtService;
 import com.kr.matitting.repository.*;
 import com.kr.matitting.service.PartyService;
@@ -22,6 +20,8 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import static com.kr.matitting.constant.Role.HOST;
 
 @Controller
 @RequiredArgsConstructor
@@ -171,6 +171,11 @@ public class testController {
         partyRepository.save(party1);
         Long party1Id = party1.getId();
 
+        ChatRoom room1 = new ChatRoom(party1, user1, party1.getPartyTitle());
+        chatRoomRepository.save(room1);
+        ChatUser chatUser1 = new ChatUser(room1, user1, HOST);
+        chatUserRepository.save(chatUser1);
+
         Party party2 = Party.builder()
                 .partyTitle("잔디개발자와 피자를 먹자!")
                 .partyContent("페페로니 vs 하와이안!")
@@ -193,6 +198,11 @@ public class testController {
                 .build();
         partyRepository.save(party2);
         Long party2Id = party2.getId();
+
+        ChatRoom room2 = new ChatRoom(party2, user2, party2.getPartyTitle());
+        chatRoomRepository.save(room2);
+        ChatUser chatUser2 = new ChatUser(room2, user2, HOST);
+        chatUserRepository.save(chatUser2);
 
         PartyJoin partyJoin1 = PartyJoin.builder()
                 .party(party1)

--- a/src/main/java/com/kr/matitting/dto/ResponseChatDto.java
+++ b/src/main/java/com/kr/matitting/dto/ResponseChatDto.java
@@ -1,5 +1,6 @@
 package com.kr.matitting.dto;
 
+import com.kr.matitting.constant.MessageType;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,4 +17,5 @@ public class ResponseChatDto {
     private String message;
     private String imgUrl;
     private LocalDateTime createAt;
+    private MessageType messageType;
 }

--- a/src/main/java/com/kr/matitting/entity/Chat.java
+++ b/src/main/java/com/kr/matitting/entity/Chat.java
@@ -1,5 +1,6 @@
 package com.kr.matitting.entity;
 
+import com.kr.matitting.constant.MessageType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,10 +27,15 @@ public class Chat extends BaseTimeEntity{
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
 
-    public Chat(ChatUser chatUser, ChatRoom chatRoom, String message){
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 100)
+    private MessageType messageType;
+
+    public Chat(ChatUser chatUser, ChatRoom chatRoom, String message, MessageType messageType){
         this.sendUser = chatUser;
         this.message = message;
         this.chatRoom = chatRoom;
+        this.messageType = messageType;
     }
 
 }

--- a/src/main/java/com/kr/matitting/entity/ChatUser.java
+++ b/src/main/java/com/kr/matitting/entity/ChatUser.java
@@ -5,11 +5,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "chat_user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Setter
 public class ChatUser extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,6 +31,9 @@ public class ChatUser extends BaseTimeEntity{
 
     @Enumerated(EnumType.STRING)
     private Role userRole;
+
+    @Column(name ="is_deleted", nullable = false)
+    private boolean isDeleted = false;
 
     public ChatUser(ChatRoom chatRoom, User user, Role userRole) {
         this.chatRoom = chatRoom;

--- a/src/main/java/com/kr/matitting/repository/ChatRepositoryCustomImpl.java
+++ b/src/main/java/com/kr/matitting/repository/ChatRepositoryCustomImpl.java
@@ -47,6 +47,7 @@ public class ChatRepositoryCustomImpl {
                         .message(chat.getMessage())
                         .imgUrl(chat.getSendUser().getUser().getImgUrl())
                         .createAt(chat.getCreateDate())
+                        .messageType(chat.getMessageType())
                         .build())
                 .toList();
 

--- a/src/main/java/com/kr/matitting/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/kr/matitting/repository/ChatRoomRepositoryImpl.java
@@ -36,9 +36,9 @@ public class ChatRoomRepositoryImpl {
                 .from(chatRoom)
                 .join(chatRoom.chatUserList, chatUser)
                 .leftJoin(chat).on(chat.chatRoom.eq(chatRoom))
-                .where(chatUser.user.id.eq(userId))
+                .where(chatUser.user.id.eq(userId).and(chatUser.isDeleted.eq(false)))
                 .groupBy(chatRoom.id)
-                .orderBy(chat.createDate.max().desc())
+                .orderBy(chatRoom.modifiedDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
@@ -70,9 +70,11 @@ public class ChatRoomRepositoryImpl {
                 .from(chatRoom)
                 .join(chatRoom.chatUserList, chatUser)
                 .leftJoin(chat).on(chat.chatRoom.eq(chatRoom))
-                .where(chatUser.user.id.eq(userId).and(chatRoom.title.containsIgnoreCase(searchTitle)))
+                .where(chatUser.user.id.eq(userId).
+                        and(chatRoom.title.containsIgnoreCase(searchTitle)).
+                        and(chatUser.isDeleted.eq(false)))
                 .groupBy(chatRoom.id)
-                .orderBy(chat.createDate.max().desc())
+                .orderBy(chatRoom.modifiedDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
@@ -113,6 +115,17 @@ public class ChatRoomRepositoryImpl {
                 .join(chatUser.chatRoom, chatRoom)
                 .where(chatUser.user.id.eq(userId))
                 .fetchOne();
+    }
+
+    public List<ChatUser> getChatUsers(Long roomId) {
+        JPAQuery<ChatUser> query = queryFactory
+                .select(chatUser)
+                .from(chatUser)
+                .where(chatUser.chatRoom.id.eq(roomId).and(chatUser.isDeleted.eq(false)))
+                .orderBy(chatUser.id.asc());
+
+        List<ChatUser> chatUsers = query.fetch();
+        return chatUsers;
     }
 }
 

--- a/src/main/java/com/kr/matitting/repository/ChatUserRepository.java
+++ b/src/main/java/com/kr/matitting/repository/ChatUserRepository.java
@@ -10,4 +10,6 @@ public interface ChatUserRepository extends JpaRepository<ChatUser, Long> {
     Optional<ChatUser> findByUserIdAndChatRoomId(Long userId, Long roomId);
     List<ChatUser> findByChatRoomId(Long roomId);
     List<ChatUser> findByUserId(Long userId);
+
+    Optional<ChatUser> findById(Long userId);
 }

--- a/src/main/java/com/kr/matitting/service/EntityFacade.java
+++ b/src/main/java/com/kr/matitting/service/EntityFacade.java
@@ -78,6 +78,14 @@ public class EntityFacade {
             throw new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER_INFO);
         return chatUserByUserIdAndChatRoomId.get();
     }
+
+    public ChatUser getChatUserByChatUserId(Long userId) {
+        Optional<ChatUser> chatUserByUserIdAndChatRoomId = chatUserRepository.findById(userId);
+        if (chatUserByUserIdAndChatRoomId.isEmpty())
+            throw new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER_INFO);
+        return chatUserByUserIdAndChatRoomId.get();
+    }
+
     public List<ChatUser> getChatUsersByUserId(Long userId) {
         List<ChatUser> ChatUsersByUserId = chatUserRepository.findByUserId(userId);
         if (ChatUsersByUserId.isEmpty()) throw new ChatException(ChatExceptionType.IS_NOT_HAVE_CHAT_ROOM);


### PR DESCRIPTION
### 추가 및 수정 사항
- 채팅방 조회 시 채팅방이 중복되어 조회되는 오류를 수정
- 채팅에 메세지 타입을 추가하여 FE 에서 채팅메세지 분기 처리를 가능하게 함
- 채팅유저 강퇴 시 채팅 유저 deleted 컬럼을 추가하여 상태를 변경하도록 함
- matitting3 API에서 파티 생성 시 채팅정보는 생성되고 있지 않아 추가함