### PR TITLE
FE Issue 요청사항 수정

### DIFF
--- a/src/main/java/com/kr/matitting/controller/NotificationController.java
+++ b/src/main/java/com/kr/matitting/controller/NotificationController.java
@@ -30,4 +30,10 @@ public class NotificationController {
         response.setHeader("X-Accel-Buffering", "no");
         return ResponseEntity.ok(notificationService.subscribe(userId, lastEventId));
     }
+
+    @Operation(summary = "알림 내역 조회", description = "알림 subscribe시 그동안의 알림 내역을 가져오는 API")
+    @GetMapping
+    public ResponseEntity<?> getNotifications(@AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(notificationService.getNotifications(userId));
+    }
 }

--- a/src/main/java/com/kr/matitting/service/EntityFacade.java
+++ b/src/main/java/com/kr/matitting/service/EntityFacade.java
@@ -37,6 +37,10 @@ public class EntityFacade {
         return userById.get();
     }
 
+    public Optional<User> getOptUser(Long userId) {
+        return userRepository.findById(userId);
+    }
+
     public Party getParty(Long partyId) {
         Optional<Party> partyById = partyRepository.findById(partyId);
         if (partyById.isEmpty()) throw new PartyException(PartyExceptionType.NOT_FOUND_PARTY);

--- a/src/main/java/com/kr/matitting/service/NotificationService.java
+++ b/src/main/java/com/kr/matitting/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.kr.matitting.service;
 
 import com.kr.matitting.constant.NotificationType;
 import com.kr.matitting.dto.NotificationDto;
+import com.kr.matitting.dto.NotificationDto.Response;
 import com.kr.matitting.entity.Notification;
 import com.kr.matitting.entity.Party;
 import com.kr.matitting.entity.User;
@@ -55,13 +56,20 @@ public class NotificationService {
 
         if (hasLostData(lastEventId)) {
             sendLostData(lastEventId, user, emitterId, emitter);
-        } else {
-            List<Notification> allByReceiverId = notificationRepository.findAllByReceiver_Id(user.getId());
-            allByReceiverId.sort(Comparator.comparing(Notification::getId));
-            allByReceiverId.forEach(notification -> sendNotification(emitter, notification.getEventId(), NotificationDto.Response.createResponse(notification)));
         }
+//        else {
+//            List<Notification> allByReceiverId = notificationRepository.findAllByReceiver_Id(user.getId());
+//            allByReceiverId.sort(Comparator.comparing(Notification::getId));
+//            allByReceiverId.forEach(notification -> sendNotification(emitter, notification.getEventId(), NotificationDto.Response.createResponse(notification)));
+//        }
 
         return emitter;
+    }
+
+    public List<Response> getNotifications(Long userId) {
+        List<Notification> allByReceiverId = notificationRepository.findAllByReceiver_Id(userId);
+        allByReceiverId.sort(Comparator.comparing(Notification::getId));
+        return allByReceiverId.stream().map(notification -> Response.createResponse(notification)).toList();
     }
 
     /**

--- a/src/main/java/com/kr/matitting/service/PartyService.java
+++ b/src/main/java/com/kr/matitting/service/PartyService.java
@@ -43,11 +43,11 @@ public class PartyService {
     private final EntityFacade entityFacade;
 
     public ResponsePartyDetailDto getPartyInfo(Long userId, Long partyId) {
-        User user = entityFacade.getUser(userId);
+        Optional<User> optUser = entityFacade.getOptUser(userId);
         Party party = entityFacade.getParty(partyId);
         increaseHit(partyId);
 
-        return ResponsePartyDetailDto.from(party, user);
+        return ResponsePartyDetailDto.from(party, optUser.get());
     }
 
     public void increaseHit(Long partyId) {


### PR DESCRIPTION
### 이슈 사항
1. 파티 현황 조회 시 400 error
-> entityfacade를 사용하며, 파티 조회 시 token을 안넣으면 400 에러 발생하던 것을 수정
2. 알림 11개 이상 SSE 연결 시 Connection Pool 오류
-> subscribe에 JPA기능을 활용하기 때문에, DB Connection이 해당 SSE 연결이 끊어질 때 가지 Active 상태가 되어, 10개를 전부 소모 시 에러가 발생하여, subscribe시 기존 해당 유저의 알림 데이터를 가져오는 부분을 API로 분리하였다